### PR TITLE
Fix issue #8: preserve undo history across team swaps

### DIFF
--- a/app.js
+++ b/app.js
@@ -432,7 +432,32 @@ function swapTeams() {
         team2Score: set.team1Score
     }));
 
-    state.pointHistory = [];
+    state.pointHistory = state.pointHistory.map(snap => ({
+        ...snap,
+        team1Score: snap.team2Score,
+        team2Score: snap.team1Score,
+        team1Sets: snap.team2Sets,
+        team2Sets: snap.team1Sets,
+        serving: snap.serving === 1 ? 2 : 1,
+        team1Rotation: snap.team2Rotation,
+        team2Rotation: snap.team1Rotation,
+        team1Subs: snap.team2Subs,
+        team2Subs: snap.team1Subs,
+        team1LiberoIn: snap.team2LiberoIn,
+        team2LiberoIn: snap.team1LiberoIn,
+        currentSetPoints: snap.currentSetPoints.map(p => ({
+            ...p,
+            team: p.team === 1 ? 2 : 1,
+            team1Score: p.team2Score,
+            team2Score: p.team1Score
+        })),
+        setHistory: snap.setHistory.map(s => ({
+            ...s,
+            winner: s.winner === 1 ? 2 : 1,
+            team1Score: s.team2Score,
+            team2Score: s.team1Score
+        }))
+    }));
 
     updateDisplay();
 }


### PR DESCRIPTION
## Summary
- Replaces `state.pointHistory = [];` in `swapTeams()` with a `.map()` that transforms each snapshot's team1/team2 fields in-place
- Mirrors the existing flip pattern already applied to `currentSetPoints` and `setHistory` on swap
- All 14 snapshot fields from `addPoint()` are accounted for; `undoLastPoint()` is untouched

## Test plan
- [ ] Score several points, click swap-teams, verify undo still walks back through pre-swap points
- [ ] Double-swap mid-undo-walk — undo continues working correctly
- [ ] Score a post-swap point, then undo — restores normally
- [ ] Swap with empty history (no points yet) — no error, no-op
- [ ] Verify serving indicator, rotation, subs, and libero state all restore correctly on undo after swap

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)