### PR TITLE
Add confirmation dialog when starting a new match mid-game

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *venv
+docs/
+.superpowers/

--- a/app.js
+++ b/app.js
@@ -54,7 +54,7 @@ let setBreakInterval = null;
 
 function init() {
     document.getElementById('startMatch').addEventListener('click', startMatch);
-    document.getElementById('newMatch').addEventListener('click', resetToSetup);
+    document.getElementById('newMatch').addEventListener('click', showNewMatchModal);
     document.getElementById('playAgain').addEventListener('click', resetToSetup);
     document.getElementById('undoPoint').addEventListener('click', undoLastPoint);
 
@@ -74,6 +74,11 @@ function init() {
     document.getElementById('continueSetBreak').addEventListener('click', closeSetBreakModal);
     document.getElementById('confirmRotation').addEventListener('click', confirmRotationSetup);
     document.getElementById('cancelSub').addEventListener('click', closeSubModal);
+    document.getElementById('cancelNewMatch').addEventListener('click', closeNewMatchModal);
+    document.getElementById('confirmNewMatch').addEventListener('click', () => {
+        closeNewMatchModal();
+        resetToSetup();
+    });
 
     document.querySelectorAll('.rotation-setup-pos').forEach(pos => {
         pos.addEventListener('click', handlePositionClick);
@@ -355,6 +360,49 @@ function makeSubstitution(team, position, newPlayer, isLibero) {
 
     rotation[rotationIndex] = newPlayer;
     updateDisplay();
+}
+
+function showNewMatchModal() {
+    const summary = document.getElementById('confirmScoreSummary');
+    const team1Color = state.team1OriginalId === 'A' ? '#667eea' : '#f5576c';
+    const team2Color = state.team2OriginalId === 'A' ? '#667eea' : '#f5576c';
+
+    let rows = '';
+    state.setHistory.forEach((s, i) => {
+        const t1Won = s.winner === 1;
+        rows += `
+            <div class="confirm-set-row">
+                <span class="${t1Won ? 'confirm-score-winner' : 'confirm-score-loser'}">${s.team1Score}</span>
+                <span class="confirm-set-label">Set ${i + 1}</span>
+                <span class="${!t1Won ? 'confirm-score-winner' : 'confirm-score-loser'}">${s.team2Score}</span>
+            </div>`;
+    });
+
+    rows += `
+        <div class="confirm-set-row confirm-set-live">
+            <span class="confirm-score-winner">${state.team1Score}</span>
+            <span class="confirm-set-label confirm-set-label-live">Set ${state.currentSet} · live</span>
+            <span class="confirm-score-winner">${state.team2Score}</span>
+        </div>`;
+
+    summary.innerHTML = `
+        <div class="confirm-team-header">
+            <span style="color:${team1Color}">${state.team1Name}</span>
+            <span class="confirm-sets-label">Sets</span>
+            <span style="color:${team2Color}">${state.team2Name}</span>
+        </div>
+        <div class="confirm-sets-tally">
+            <span>${state.team1Sets}</span>
+            <span class="confirm-tally-sep">–</span>
+            <span>${state.team2Sets}</span>
+        </div>
+        ${rows}`;
+
+    document.getElementById('newMatchModal').classList.remove('hidden');
+}
+
+function closeNewMatchModal() {
+    document.getElementById('newMatchModal').classList.add('hidden');
 }
 
 function closeSubModal() {

--- a/index.html
+++ b/index.html
@@ -267,6 +267,19 @@
         </div>
     </div>
 
+    <div id="newMatchModal" class="modal hidden">
+        <div class="modal-content">
+            <div class="confirm-icon">⚠️</div>
+            <h2>Start New Match?</h2>
+            <p class="confirm-subtitle">All current match data will be lost.</p>
+            <div class="confirm-score-summary" id="confirmScoreSummary"></div>
+            <div class="confirm-buttons">
+                <button class="btn btn-secondary" id="cancelNewMatch">Cancel</button>
+                <button class="btn btn-danger" id="confirmNewMatch">New Match</button>
+            </div>
+        </div>
+    </div>
+
     <footer class="credits">v2.12 | Created by Menon Pranto</footer>
 
     <script src="app.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -1289,6 +1289,51 @@ h1 {
         bottom: 5px;
         right: 10px;
     }
+
+    /* Confirmation modal – tablet/large phone */
+    .confirm-icon {
+        width: 42px;
+        height: 42px;
+        font-size: 1.2rem;
+        margin-bottom: 10px;
+    }
+
+    .confirm-subtitle {
+        font-size: 0.8rem;
+        margin-bottom: 14px;
+    }
+
+    .confirm-team-header {
+        padding: 7px 12px;
+        font-size: 0.72rem;
+    }
+
+    .confirm-sets-tally {
+        padding: 8px 12px;
+        font-size: 1.1rem;
+    }
+
+    .confirm-set-row {
+        padding: 6px 12px;
+    }
+
+    .confirm-score-winner,
+    .confirm-score-loser {
+        font-size: 0.72rem;
+    }
+
+    .confirm-set-label {
+        font-size: 0.6rem;
+        padding: 2px 5px;
+    }
+
+    .confirm-score-summary {
+        margin-bottom: 14px;
+    }
+
+    .confirm-buttons {
+        gap: 8px;
+    }
 }
 
 @media (max-width: 360px) {
@@ -1322,6 +1367,33 @@ h1 {
         width: 42px;
         height: 42px;
         font-size: 0.75rem;
+    }
+
+    /* Confirmation modal – small phones (iPhone SE etc.) */
+    .confirm-icon {
+        width: 36px;
+        height: 36px;
+        font-size: 1rem;
+        margin-bottom: 8px;
+    }
+
+    .confirm-sets-tally {
+        font-size: 1rem;
+        padding: 7px 10px;
+    }
+
+    .confirm-team-header,
+    .confirm-set-row {
+        padding: 5px 10px;
+    }
+
+    .confirm-buttons {
+        flex-direction: column;
+        gap: 6px;
+    }
+
+    .confirm-buttons .btn {
+        width: 100%;
     }
 }
 
@@ -1545,6 +1617,33 @@ h1 {
         bottom: 3px;
         right: 8px;
     }
+
+    /* Confirmation modal – landscape phones */
+    .confirm-icon {
+        width: 32px;
+        height: 32px;
+        font-size: 0.95rem;
+        margin-bottom: 6px;
+    }
+
+    .confirm-subtitle {
+        font-size: 0.75rem;
+        margin-bottom: 8px;
+    }
+
+    .confirm-score-summary {
+        margin-bottom: 10px;
+    }
+
+    .confirm-team-header,
+    .confirm-set-row {
+        padding: 4px 10px;
+    }
+
+    .confirm-sets-tally {
+        padding: 6px 10px;
+        font-size: 0.95rem;
+    }
 }
 
 /* Extra wide landscape (tablets in landscape) */
@@ -1567,4 +1666,119 @@ h1 {
         height: 30px;
         font-size: 0.7rem;
     }
+}
+
+/* ── New Match Confirmation Modal ─────────────────────────────── */
+
+.confirm-icon {
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    background: rgba(245, 87, 108, 0.12);
+    border: 1px solid rgba(245, 87, 108, 0.28);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 14px;
+    font-size: 1.5rem;
+}
+
+.confirm-subtitle {
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 0.85rem;
+    margin-bottom: 18px;
+}
+
+.confirm-score-summary {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    overflow: hidden;
+    margin-bottom: 20px;
+    text-align: left;
+}
+
+.confirm-team-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 9px 14px;
+    background: rgba(255, 255, 255, 0.04);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+    font-size: 0.78rem;
+    font-weight: 600;
+}
+
+.confirm-sets-label {
+    color: rgba(255, 255, 255, 0.3);
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.confirm-sets-tally {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 14px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    font-size: 1.3rem;
+    font-weight: 800;
+    color: #fff;
+}
+
+.confirm-tally-sep {
+    color: rgba(255, 255, 255, 0.2);
+    font-size: 0.75rem;
+}
+
+.confirm-set-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 7px 14px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.confirm-set-row:last-child {
+    border-bottom: none;
+}
+
+.confirm-set-live {
+    background: rgba(245, 87, 108, 0.05);
+}
+
+.confirm-set-label {
+    font-size: 0.65rem;
+    color: rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid transparent;
+    border-radius: 4px;
+    padding: 2px 7px;
+}
+
+.confirm-set-label-live {
+    color: rgba(245, 87, 108, 0.75);
+    background: rgba(245, 87, 108, 0.1);
+    border: 1px solid rgba(245, 87, 108, 0.2);
+}
+
+.confirm-score-winner {
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.confirm-score-loser {
+    font-size: 0.78rem;
+    color: rgba(255, 255, 255, 0.38);
+}
+
+.confirm-buttons {
+    display: flex;
+    gap: 10px;
+}
+
+.confirm-buttons .btn {
+    flex: 1;
 }


### PR DESCRIPTION
## Summary
- Wraps the "New Match" button with a confirmation modal that always appears before resetting match state
- Shows team names (coloured by team identity), overall sets tally, each completed set's score, and the current in-progress set with a red "live" badge
- Fully responsive: compact at ≤600px, stacked buttons at ≤360px, tighter spacing in landscape orientation

## Test plan
- [ ] Press New Match mid-match → confirmation dialog appears with correct scores and team colours
- [ ] Press Cancel → dialog closes, match continues unchanged
- [ ] Press New Match (confirm) → match resets to setup screen
- [ ] Press New Match at 0–0 → dialog still appears (always triggered)
- [ ] Swap teams then press New Match → dialog reflects post-swap team names/colours
- [ ] Verify on mobile viewport and landscape — no overflow, buttons stack at ≤360px

🤖 Generated with [Claude Code](https://claude.com/claude-code)