### PR TITLE
v3.0: drag-and-drop rotation, team colors, use previous rotation, chart and UX fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *venv
 docs/
 .superpowers/
+.playwright-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development
+
+No build system or dependencies. To run the app, open `index.html` directly in a browser:
+
+```bash
+open index.html
+```
+
+Deployment is automated via GitHub Actions (`.github/workflows/deploy.yml`) — any push to `main` deploys to GitHub Pages.
+
+## Architecture
+
+The app is a single-page vanilla JS application with three files:
+
+- `index.html` — all markup; four screens toggled via the `hidden` CSS class
+- `styles.css` — all styling; uses CSS variables and flexbox
+- `app.js` — all logic; single file, no modules
+
+### Screen flow
+
+Four views are shown/hidden by toggling the `hidden` class on their container divs:
+
+1. `#setup` — match configuration form
+2. `#rotationSetup` — starting rotation assignment (before each set)
+3. `#scoreboard` — active game screen
+4. `#matchResult` — post-match result
+
+Four modals are used across screens: `#subModal` (player substitution, overlays scoreboard), `#timeoutModal` (30-second countdown, overlays scoreboard), `#setBreakModal` (3-minute set break timer, shown between sets), and `#returnToSetupModal` (confirmation dialog for returning to setup mid-match).
+
+### State management
+
+All game state lives in a single global `state` object (top of `app.js`). A secondary `rotationSetupState` object holds transient rotation-setup UI state (selected position, pending assignments) and is reset each time rotation setup is shown.
+
+`updateDisplay()` is the single render function that syncs the entire UI to `state`. All mutations to `state` end with a call to `updateDisplay()`.
+
+### Undo system
+
+Before each point is added, a deep snapshot of all mutable state fields is pushed onto `state.pointHistory`. `undoLastPoint()` pops the last snapshot and restores state. On `swapTeams()`, all snapshots in `pointHistory` are remapped (team1/team2 fields swapped) so undo works correctly even after a swap. The `points` array inside each `setHistory` entry is also remapped.
+
+### Rotation array layout
+
+The rotation is stored as a flat 6-element array. The mapping between array index and court position is:
+
+```
+index: 0  1  2  3  4  5
+pos:   1  2  3  4  5  6
+```
+
+The `rotateTeam()` function shifts element 5 (position 6, server) to the front (index 0, position 1) — a clockwise rotation. The `updateRotationDisplay()` function uses a separate `positionMap = [3, 2, 1, 4, 5, 0]` to translate DOM node order (front row left-to-right: 4-3-2, back row left-to-right: 5-6-1) into rotation array indices.
+
+### Team color identity
+
+Teams are assigned a permanent color identity: 'A' and 'B'. Colors are stored in CSS variables `--team1-color` / `--team2-color` (user-editable via color picker in setup, persisted in `localStorage`). `state.team1OriginalId` and `state.team2OriginalId` track which identity ('A'/'B') each side holds, even after swaps. Colors are applied in `updateTeamColors()` and `updateRotationSetupColors()` by checking `originalId`, not position number.
+
+### Side-swap vs. team-swap
+
+There are two separate swap operations:
+- `switchSides()` — called automatically between sets; swaps names/scores/players (and `lastStartingRotation1 ↔ lastStartingRotation2`) but **not** current-set score or timeouts (those reset for the new set)
+- `swapTeams()` — triggered by the user swap button during play; swaps everything including current scores, timeouts, rotations, and serving (and `lastStartingRotation1 ↔ lastStartingRotation2`); remaps all `pointHistory` snapshots so undo remains valid across the swap
+
+### Set break flow
+
+When a set ends, `checkSetWin()` calls `showSetBreakModal(nextSetNumber)` which starts a 3-minute countdown. On modal close (`closeSetBreakModal()`): if `state.hasRotation` is false (first set of next group needs rotation setup) it calls `showNewSetRotationSetup()`; otherwise it resumes play directly. `confirmReturnToSetup()` cancels the set break interval directly to avoid triggering `showNewSetRotationSetup()` as a side effect.
+
+### "Use previous rotation" feature
+
+`state.lastStartingRotation1` and `state.lastStartingRotation2` store the flat 6-element rotation arrays from the most recently confirmed starting rotation for each team. They are written in `confirmRotationSetup()` after building `state.team1Rotation`/`team2Rotation`, and nulled in `resetMatchState()`. Both fields are included in the `beginMatch()` save/restore block so they survive the `resetMatchState()` call. The `.use-prev-rotation[data-team="1/2"]` buttons are hidden (via `updatePrevRotationButtons()`) when the corresponding field is null (set 1), and shown from set 2 onward.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ A comprehensive web-based volleyball scoresheet application for tracking matches
 
 - **Best of 3 or 5 sets** - Choose your match format
 - **Team customization** - Set team names, jersey numbers, captain, and libero
-- **Input validation** - Ensures valid jersey numbers with no duplicates
+- **Custom team colors** - Color picker with preset swatches, persisted across sessions
+- **Jersey flexibility** - Numbers, letters, and emojis supported (up to 3 characters)
+- **Input validation** - Ensures valid jerseys with no duplicates
 
 ### Scoring
 
@@ -20,10 +22,13 @@ A comprehensive web-based volleyball scoresheet application for tracking matches
 - **Set management** - Automatic set progression (25 points, final set to 15)
 - **Win by 2** - Proper volleyball scoring rules enforced
 - **Visual score log** - Timeline showing point-by-point scoring history
+- **Undo** - Revert the last point if entered incorrectly; works even after team swaps
 
 ### Rotation System
 
-- **Starting rotation setup** - Manually assign players to positions at the start of each set
+- **Starting rotation setup** - Assign players to positions by clicking or drag-and-drop
+- **Drag-and-drop** - Drag players from the palette or swap filled slots directly
+- **Repeat previous rotation** - One-tap button to reuse the previous set's starting rotation per team
 - **Automatic rotation** - Players rotate clockwise on side-out
 - **Position display** - Visual 6-position grid (4-3-2 / 5-6-1 format)
 - **Captain indicator** - Underlined jersey number for team captain
@@ -39,17 +44,19 @@ A comprehensive web-based volleyball scoresheet application for tracking matches
 - **Sub tracking** - Small indicator shows original player for each substitution
 - **Volleyball rules** - Players can only return to their original position
 
+### Match Results
+
+- **Final summary** - Set scores with total points across all sets
+- **Lead-margin charts** - Per-set score progression chart for both teams; trailing team dimmed at each segment
+- **Match control** - Return to setup at any time during the match
+
 ### Additional Features
 
 - **Service tracking** - Visual indicator shows which team is serving
 - **Timeout management** - 2 timeouts per set with 30-second countdown timer
-- **Undo functionality** - Revert the last point if entered incorrectly
-- **Team swap** - Switch sides with all data preserved
+- **Team swap** - Switch sides with all data preserved, including undo history
+- **Set break timer** - 3-minute break timer between sets
 - **Responsive design** - Works on desktop, tablet, and mobile devices
-
-## Screenshots
-
-The app features a modern dark theme with color-coded teams (blue and red) for easy differentiation.
 
 ## Installation
 
@@ -66,26 +73,29 @@ cd VolleyballReferee
 ## Usage
 
 1. **Setup Match**
-   - Enter team names
-   - Add jersey numbers (comma-separated, minimum 6)
-   - Set captain and libero numbers
+   - Enter team names and jersey numbers (comma-separated, minimum 6)
+   - Optionally set captain and libero numbers
+   - Pick team colors using the color picker or preset swatches
    - Choose best of 3 or 5 sets
 
 2. **Set Starting Rotation**
-   - Click on each position in the grid
-   - Select a player from available jersey numbers
+   - Click a position to select it, then click a jersey from the palette — or drag jerseys directly into slots
+   - Use "Use previous rotation" (shown from set 2 onward) to instantly fill a team's rotation from the prior set
    - Libero cannot be in starting rotation
 
 3. **During the Match**
-   - Tap "+1 Point" to score for either team
+   - Tap score buttons to add points
    - Tap players in rotation grid to make substitutions
    - Use timeout button when needed
    - Tap the volleyball icon to manually switch service
-   - Use undo button if you make a mistake
+   - Use the undo button to revert a point
 
 4. **Between Sets**
-   - Set up new starting rotations for both teams
-   - Match score is displayed for reference
+   - A 3-minute set break timer shows automatically
+   - Set up new starting rotations, or reuse the previous set's rotation with one tap
+
+5. **Match Result**
+   - Final score, set breakdown, total points, and per-set score charts
 
 ## Technologies Used
 
@@ -113,6 +123,7 @@ The app is fully responsive and optimized for:
 
 ## Version History
 
+- **v3.0** - Drag-and-drop rotation assignment; customizable team colors; letter/emoji jerseys; lead-margin charts; total points; return-to-setup mid-match; "use previous rotation" button; polished indoor arena theme
 - **v2.01** - Optimized landscape mode for mobile phones, reduced scrolling
 - **v1.7** - Added live demo link and GitHub Actions deployment
 - **v1.5** - Added README and deployment documentation
@@ -132,4 +143,4 @@ Created by **Menon Pranto**
 
 ## Contributing
 
- You can also open GitHub issues to suggest new features or report bugs.
+You can also open GitHub issues to suggest new features or report bugs.

--- a/app.js
+++ b/app.js
@@ -30,7 +30,9 @@ const state = {
     firstServer: 1,
     matchOver: false,
     team1OriginalId: 'A',
-    team2OriginalId: 'B'
+    team2OriginalId: 'B',
+    lastStartingRotation1: null,
+    lastStartingRotation2: null
 };
 
 const rotationSetupState = {
@@ -51,10 +53,210 @@ const TIMER_CIRCLE_CIRCUMFERENCE = 2 * Math.PI * TIMER_CIRCLE_RADIUS;
 
 let timeoutInterval = null;
 let setBreakInterval = null;
+let _scorePulseTeam = null;
+let _dndInitialized = false;
+
+function initDragAndDrop() {
+    if (_dndInitialized) return;
+    _dndInitialized = true;
+    const container = document.getElementById('rotationSetup');
+    let ghost = null;
+    let dragSource = null;
+    let dragTeam = null;
+    let dragFromPos = null;
+    let didMove = false;
+    let activePointerId = null;
+    let suppressNextClick = false;
+
+    function getRotation(team) {
+        return team === 1 ? rotationSetupState.team1Rotation : rotationSetupState.team2Rotation;
+    }
+
+    function getPlayerAt(team, pos) { return getRotation(team)[pos] || null; }
+
+    function setPlayer(team, pos, player) {
+        getRotation(team)[pos] = player;
+    }
+
+    function clearPlayer(team, pos) {
+        getRotation(team)[pos] = null;
+    }
+
+    function refreshUI(team) {
+        updateAvailablePlayers(team);
+        updateRotationSetupDisplay();
+    }
+
+    function createGhost(el) {
+        ghost = el.cloneNode(true);
+        ghost.style.cssText = `position:fixed;pointer-events:none;z-index:9999;opacity:0.85;transform:scale(1.15);transition:none;`;
+        document.body.appendChild(ghost);
+    }
+
+    function moveGhost(x, y) {
+        if (!ghost) return;
+        const r = ghost.getBoundingClientRect();
+        ghost.style.left = `${x - r.width / 2}px`;
+        ghost.style.top = `${y - r.height / 2}px`;
+    }
+
+    function removeGhost() {
+        if (ghost) { ghost.remove(); ghost = null; }
+        document.querySelectorAll('.drop-hint').forEach(el => el.classList.remove('drop-hint'));
+    }
+
+    function getDropTarget(x, y) {
+        if (!ghost) return null;
+        ghost.style.display = 'none';
+        const el = document.elementFromPoint(x, y);
+        ghost.style.display = '';
+        if (!el) return null;
+        return el.closest('.rotation-setup-pos') || el.closest('.available-player');
+    }
+
+    container.addEventListener('pointerdown', e => {
+        suppressNextClick = false;
+        const src = e.target.closest('.available-player:not(.used), .rotation-setup-pos');
+        if (!src) return;
+        const team = parseInt(src.dataset.team);
+        if (!team) return;
+
+        const isPos = src.classList.contains('rotation-setup-pos');
+        const fromPos = isPos ? parseInt(src.dataset.pos) : null;
+        if (isPos && !getRotation(team)[fromPos]) return;
+
+        dragSource = src;
+        dragTeam = team;
+        dragFromPos = fromPos;
+        didMove = false;
+        activePointerId = e.pointerId;
+        src.setPointerCapture(e.pointerId);
+        createGhost(src);
+        moveGhost(e.clientX, e.clientY);
+        src.classList.add('dragging');
+        e.preventDefault();
+    }, { passive: false });
+
+    container.addEventListener('pointermove', e => {
+        if (!dragSource || e.pointerId !== activePointerId) return;
+        didMove = true;
+        moveGhost(e.clientX, e.clientY);
+
+        document.querySelectorAll('.drop-hint').forEach(el => el.classList.remove('drop-hint'));
+        const target = getDropTarget(e.clientX, e.clientY);
+        if (target && target.classList.contains('rotation-setup-pos') && parseInt(target.dataset.team) === dragTeam) {
+            target.classList.add('drop-hint');
+        }
+    });
+
+    container.addEventListener('pointerup', e => {
+        if (!dragSource || e.pointerId !== activePointerId) return;
+        dragSource.classList.remove('dragging');
+
+        if (!didMove) {
+            removeGhost();
+            dragSource = null;
+            return;
+        }
+
+        suppressNextClick = true;
+
+        const target = getDropTarget(e.clientX, e.clientY);
+        removeGhost();
+
+        if (target && target.classList.contains('rotation-setup-pos')) {
+            const targetTeam = parseInt(target.dataset.team);
+            const targetPos = parseInt(target.dataset.pos);
+
+            if (targetTeam === dragTeam) {
+                const player = dragFromPos !== null
+                    ? getPlayerAt(dragTeam, dragFromPos)
+                    : dragSource.dataset.player;
+
+                if (player) {
+                    const displaced = getPlayerAt(dragTeam, targetPos);
+                    setPlayer(dragTeam, targetPos, player);
+                    if (dragFromPos !== null) {
+                        // Slot-to-slot: put displaced player back in source slot
+                        setPlayer(dragTeam, dragFromPos, displaced);
+                    }
+                    refreshUI(dragTeam);
+                }
+            }
+        }
+
+        dragSource = null;
+        dragTeam = null;
+        dragFromPos = null;
+        activePointerId = null;
+    });
+
+    container.addEventListener('pointercancel', () => {
+        if (dragSource) dragSource.classList.remove('dragging');
+        removeGhost();
+        dragSource = null;
+        dragTeam = null;
+        dragFromPos = null;
+        activePointerId = null;
+    });
+
+    container.addEventListener('click', e => {
+        if (!suppressNextClick) return;
+        suppressNextClick = false;
+        if (e.target.closest('.rotation-setup-pos, .available-player')) {
+            e.stopPropagation();
+        }
+    }, true);
+}
+
+function hexToRgb(hex) {
+    let h = hex.replace('#', '');
+    if (h.length === 3) h = h[0]+h[0]+h[1]+h[1]+h[2]+h[2];
+    const v = parseInt(h, 16);
+    return `${(v >> 16) & 255}, ${(v >> 8) & 255}, ${v & 255}`;
+}
+
+function applyTeamColors(c1, c2) {
+    const root = document.documentElement.style;
+    root.setProperty('--team1-color', c1);
+    root.setProperty('--team1-rgb', hexToRgb(c1));
+    root.setProperty('--team2-color', c2);
+    root.setProperty('--team2-rgb', hexToRgb(c2));
+    document.getElementById('team1Color').value = c1;
+    document.getElementById('team2Color').value = c2;
+    try { localStorage.setItem('vb-team-colors', JSON.stringify({ c1, c2 })); } catch (_) {}
+}
 
 function init() {
+    // Restore saved team colors
+    try {
+        const saved = JSON.parse(localStorage.getItem('vb-team-colors') || 'null');
+        if (saved) applyTeamColors(saved.c1, saved.c2);
+    } catch (_) {}
+
+    document.getElementById('team1Color').addEventListener('input', e => {
+        const c2 = getComputedStyle(document.documentElement).getPropertyValue('--team2-color').trim();
+        applyTeamColors(e.target.value, c2);
+    });
+    document.getElementById('team2Color').addEventListener('input', e => {
+        const c1 = getComputedStyle(document.documentElement).getPropertyValue('--team1-color').trim();
+        applyTeamColors(c1, e.target.value);
+    });
+    document.querySelectorAll('.color-swatch').forEach(btn => {
+        btn.addEventListener('click', e => {
+            const team = e.currentTarget.dataset.team;
+            const color = e.currentTarget.dataset.color;
+            if (team === '1') {
+                const c2 = getComputedStyle(document.documentElement).getPropertyValue('--team2-color').trim();
+                applyTeamColors(color, c2);
+            } else {
+                const c1 = getComputedStyle(document.documentElement).getPropertyValue('--team1-color').trim();
+                applyTeamColors(c1, color);
+            }
+        });
+    });
+
     document.getElementById('startMatch').addEventListener('click', startMatch);
-    document.getElementById('newMatch').addEventListener('click', showNewMatchModal);
     document.getElementById('playAgain').addEventListener('click', resetToSetup);
     document.getElementById('undoPoint').addEventListener('click', undoLastPoint);
 
@@ -74,11 +276,9 @@ function init() {
     document.getElementById('continueSetBreak').addEventListener('click', closeSetBreakModal);
     document.getElementById('confirmRotation').addEventListener('click', confirmRotationSetup);
     document.getElementById('cancelSub').addEventListener('click', closeSubModal);
-    document.getElementById('cancelNewMatch').addEventListener('click', closeNewMatchModal);
-    document.getElementById('confirmNewMatch').addEventListener('click', () => {
-        closeNewMatchModal();
-        resetToSetup();
-    });
+    document.getElementById('returnToSetup').addEventListener('click', showReturnToSetupModal);
+    document.getElementById('cancelReturnToSetup').addEventListener('click', closeReturnToSetupModal);
+    document.getElementById('confirmReturnToSetup').addEventListener('click', confirmReturnToSetup);
 
     document.querySelectorAll('.rotation-setup-pos').forEach(pos => {
         pos.addEventListener('click', handlePositionClick);
@@ -86,6 +286,21 @@ function init() {
 
     document.querySelectorAll('#rotation1 .rotation-pos, #rotation2 .rotation-pos').forEach(pos => {
         pos.addEventListener('click', handleGamePositionClick);
+    });
+
+    document.querySelectorAll('.use-prev-rotation').forEach(btn => {
+        btn.addEventListener('click', e => {
+            const team = parseInt(e.currentTarget.dataset.team);
+            const prev = team === 1 ? state.lastStartingRotation1 : state.lastStartingRotation2;
+            if (!prev || prev.length < 6) return;
+            const target = team === 1 ? rotationSetupState.team1Rotation : rotationSetupState.team2Rotation;
+            for (let i = 0; i < 6; i++) target[i + 1] = prev[i];
+            updateAvailablePlayers(team);
+            updateRotationSetupDisplay();
+            rotationSetupState.selectedPosition = null;
+            rotationSetupState.selectedTeam = null;
+            document.querySelectorAll('.rotation-setup-pos').forEach(p => p.classList.remove('selected'));
+        });
     });
 }
 
@@ -274,46 +489,51 @@ function showSubModal(team, position) {
 
     let html = '';
 
+    const makeSubEl = (player, classes, attrs = {}) => {
+        const el = document.createElement('div');
+        el.className = ['sub-option', ...classes].join(' ');
+        el.dataset.player = player;
+        el.textContent = player;
+        Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v));
+        return el;
+    };
+
+    const fragment = document.createDocumentFragment();
+
     if (subs[rotationIndex] && currentPlayer !== subs[rotationIndex].original) {
         const original = subs[rotationIndex].original;
-        html += `<div class="sub-option return-player" data-player="${original}" title="Return original player">${original}</div>`;
+        fragment.appendChild(makeSubEl(original, ['return-player'], { title: 'Return original player' }));
     }
 
     if (libero && !playersOnCourt.includes(libero)) {
         if (isBackRow) {
-            html += `<div class="sub-option libero" data-player="${libero}" data-is-libero="true" title="Libero">${libero}</div>`;
+            fragment.appendChild(makeSubEl(libero, ['libero'], { 'data-is-libero': 'true', title: 'Libero' }));
         } else {
-            html += `<div class="sub-option libero disabled" data-player="${libero}" title="Libero can only sub in back row">${libero}</div>`;
+            fragment.appendChild(makeSubEl(libero, ['libero', 'disabled'], { title: 'Libero can only sub in back row' }));
         }
-    }
-
-    if (currentPlayer === libero && liberoIn !== null) {
-        const originalPlayer = team === 1 ?
-            state.team1Rotation.find((p, i) => state.team1Subs[i]?.liberoFor === currentPlayer) :
-            state.team2Rotation.find((p, i) => state.team2Subs[i]?.liberoFor === currentPlayer);
     }
 
     availableSubs.forEach(player => {
         if (player === libero) return;
-
-        // Skip if already added as return player for current position
-        if (subs[rotationIndex] && player === subs[rotationIndex].original) {
-            return;
-        }
+        if (subs[rotationIndex] && player === subs[rotationIndex].original) return;
 
         const subEntry = Object.entries(subs).find(([idx, sub]) => sub.original === player);
         if (subEntry) {
             const [subIdx] = subEntry;
             if (parseInt(subIdx) !== rotationIndex) {
-                html += `<div class="sub-option disabled" data-player="${player}" title="Can only return to position ${parseInt(subIdx) + 1}">${player}</div>`;
+                fragment.appendChild(makeSubEl(player, ['disabled'], { title: `Can only return to position ${parseInt(subIdx) + 1}` }));
                 return;
             }
         }
-
-        html += `<div class="sub-option" data-player="${player}">${player}</div>`;
+        fragment.appendChild(makeSubEl(player, []));
     });
 
-    optionsContainer.innerHTML = html || '<p>No substitutes available</p>';
+    optionsContainer.innerHTML = '';
+    if (fragment.childElementCount === 0) {
+        optionsContainer.innerHTML = '<p>No substitutes available</p>';
+    } else {
+        optionsContainer.appendChild(fragment);
+    }
 
     optionsContainer.querySelectorAll('.sub-option:not(.disabled)').forEach(opt => {
         opt.addEventListener('click', handleSubSelect);
@@ -362,10 +582,13 @@ function makeSubstitution(team, position, newPlayer, isLibero) {
     updateDisplay();
 }
 
-function showNewMatchModal() {
-    const summary = document.getElementById('confirmScoreSummary');
-    const team1Color = state.team1OriginalId === 'A' ? '#667eea' : '#f5576c';
-    const team2Color = state.team2OriginalId === 'A' ? '#667eea' : '#f5576c';
+function showReturnToSetupModal() {
+    const summary = document.getElementById('returnToSetupScoreSummary');
+    const cssStyle = getComputedStyle(document.documentElement);
+    const colorA = cssStyle.getPropertyValue('--team1-color').trim();
+    const colorB = cssStyle.getPropertyValue('--team2-color').trim();
+    const team1Color = state.team1OriginalId === 'A' ? colorA : colorB;
+    const team2Color = state.team2OriginalId === 'A' ? colorA : colorB;
 
     let rows = '';
     state.setHistory.forEach((s, i) => {
@@ -377,7 +600,6 @@ function showNewMatchModal() {
                 <span class="${!t1Won ? 'confirm-score-winner' : 'confirm-score-loser'}">${s.team2Score}</span>
             </div>`;
     });
-
     rows += `
         <div class="confirm-set-row confirm-set-live">
             <span class="confirm-score-winner">${state.team1Score}</span>
@@ -387,9 +609,9 @@ function showNewMatchModal() {
 
     summary.innerHTML = `
         <div class="confirm-team-header">
-            <span style="color:${team1Color}">${state.team1Name}</span>
+            <span style="color:${team1Color}">${escapeHtml(state.team1Name)}</span>
             <span class="confirm-sets-label">Sets</span>
-            <span style="color:${team2Color}">${state.team2Name}</span>
+            <span style="color:${team2Color}">${escapeHtml(state.team2Name)}</span>
         </div>
         <div class="confirm-sets-tally">
             <span>${state.team1Sets}</span>
@@ -398,11 +620,20 @@ function showNewMatchModal() {
         </div>
         ${rows}`;
 
-    document.getElementById('newMatchModal').classList.remove('hidden');
+    document.getElementById('returnToSetupModal').classList.remove('hidden');
 }
 
-function closeNewMatchModal() {
-    document.getElementById('newMatchModal').classList.add('hidden');
+function closeReturnToSetupModal() {
+    document.getElementById('returnToSetupModal').classList.add('hidden');
+}
+
+function confirmReturnToSetup() {
+    closeReturnToSetupModal();
+    closeTimeoutModal();
+    if (setBreakInterval) { clearInterval(setBreakInterval); setBreakInterval = null; }
+    document.getElementById('setBreakModal').classList.add('hidden');
+    closeSubModal();
+    resetToSetup();
 }
 
 function closeSubModal() {
@@ -441,12 +672,19 @@ function switchSides() {
     [state.team1Captain, state.team2Captain] = [state.team2Captain, state.team1Captain];
     [state.team1Libero, state.team2Libero] = [state.team2Libero, state.team1Libero];
     [state.team1OriginalId, state.team2OriginalId] = [state.team2OriginalId, state.team1OriginalId];
+    [state.lastStartingRotation1, state.lastStartingRotation2] = [state.lastStartingRotation2, state.lastStartingRotation1];
 
     state.setHistory = state.setHistory.map(set => ({
         ...set,
         winner: set.winner === 1 ? 2 : 1,
         team1Score: set.team2Score,
-        team2Score: set.team1Score
+        team2Score: set.team1Score,
+        points: (set.points || []).map(p => ({
+            ...p,
+            team: p.team === 1 ? 2 : 1,
+            team1Score: p.team2Score,
+            team2Score: p.team1Score
+        }))
     }));
 }
 
@@ -462,6 +700,7 @@ function swapTeams() {
     [state.team1Subs, state.team2Subs] = [state.team2Subs, state.team1Subs];
     [state.team1LiberoIn, state.team2LiberoIn] = [state.team2LiberoIn, state.team1LiberoIn];
     [state.team1OriginalId, state.team2OriginalId] = [state.team2OriginalId, state.team1OriginalId];
+    [state.lastStartingRotation1, state.lastStartingRotation2] = [state.lastStartingRotation2, state.lastStartingRotation1];
 
     state.serving = state.serving === 1 ? 2 : 1;
     state.firstServer = state.firstServer === 1 ? 2 : 1;
@@ -477,7 +716,13 @@ function swapTeams() {
         ...set,
         winner: set.winner === 1 ? 2 : 1,
         team1Score: set.team2Score,
-        team2Score: set.team1Score
+        team2Score: set.team1Score,
+        points: (set.points || []).map(p => ({
+            ...p,
+            team: p.team === 1 ? 2 : 1,
+            team1Score: p.team2Score,
+            team2Score: p.team1Score
+        }))
     }));
 
     state.pointHistory = state.pointHistory.map(snap => ({
@@ -503,7 +748,13 @@ function swapTeams() {
             ...s,
             winner: s.winner === 1 ? 2 : 1,
             team1Score: s.team2Score,
-            team2Score: s.team1Score
+            team2Score: s.team1Score,
+            points: (s.points || []).map(p => ({
+                ...p,
+                team: p.team === 1 ? 2 : 1,
+                team1Score: p.team2Score,
+                team2Score: p.team1Score
+            }))
         }))
     }));
 
@@ -529,7 +780,7 @@ function startMatch() {
     const errorDiv = document.getElementById('setupError');
     if (errors.length > 0) {
         errorDiv.innerHTML = '<strong>Please fix the following errors:</strong><ul>' +
-            errors.map(e => `<li>${e}</li>`).join('') + '</ul>';
+            errors.map(e => `<li>${escapeHtml(e)}</li>`).join('') + '</ul>';
         errorDiv.classList.remove('hidden');
         return;
     }
@@ -563,12 +814,12 @@ function validateSetup(team1Name, team2Name, team1Players, team2Players, team1Ca
     const errors = [];
 
     const validateTeam = (teamName, players, captain, libero) => {
-        const invalidNumbers = players.filter(n => !isValidInteger(n));
+        const invalidNumbers = players.filter(n => !isValidJersey(n));
         if (invalidNumbers.length > 0) {
-            errors.push(`${teamName}: Invalid jersey number(s): ${invalidNumbers.join(', ')} (must be integers)`);
+            errors.push(`${teamName}: Invalid jersey identifier(s): ${invalidNumbers.join(', ')} (max 3 chars, no HTML special chars)`);
         }
 
-        const validPlayers = players.filter(n => isValidInteger(n));
+        const validPlayers = players.filter(n => isValidJersey(n));
 
         const duplicates = validPlayers.filter((item, index) => validPlayers.indexOf(item) !== index);
         if (duplicates.length > 0) {
@@ -585,16 +836,16 @@ function validateSetup(team1Name, team2Name, team1Players, team2Players, team1Ca
         }
 
         if (captain) {
-            if (!isValidInteger(captain)) {
-                errors.push(`${teamName}: Captain number must be a valid integer`);
+            if (!isValidJersey(captain)) {
+                errors.push(`${teamName}: Captain jersey must be 1–3 characters`);
             } else if (validPlayers.length > 0 && !validPlayers.includes(captain)) {
                 errors.push(`${teamName}: Captain #${captain} is not in the jersey numbers list`);
             }
         }
 
         if (libero) {
-            if (!isValidInteger(libero)) {
-                errors.push(`${teamName}: Libero number must be a valid integer`);
+            if (!isValidJersey(libero)) {
+                errors.push(`${teamName}: Libero jersey must be 1–3 characters`);
             } else if (validPlayers.length > 0 && !validPlayers.includes(libero)) {
                 errors.push(`${teamName}: Libero #${libero} is not in the jersey numbers list`);
             }
@@ -616,11 +867,17 @@ function validateSetup(team1Name, team2Name, team1Players, team2Players, team1Ca
     return errors;
 }
 
-function isValidInteger(value) {
-    if (value === null || value === '') return false;
-    const num = Number(value);
-    return Number.isInteger(num) && num > 0;
+function isValidJersey(value) {
+    const v = String(value).trim();
+    if (v.length === 0) return false;
+    if ([...v].length > 3) return false;
+    return !/[<>&"']/.test(v);
 }
+
+function escapeHtml(str) {
+    return String(str).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
 
 function showRotationSetup() {
     document.getElementById('setup').classList.add('hidden');
@@ -644,6 +901,8 @@ function showRotationSetup() {
     header.textContent = 'Set Starting Rotations';
 
     document.getElementById('rotationSetupSetScore').classList.add('hidden');
+    updatePrevRotationButtons();
+    initDragAndDrop();
 }
 
 function showNewSetRotationSetup() {
@@ -669,7 +928,16 @@ function showNewSetRotationSetup() {
 
     const scoreDisplay = document.getElementById('rotationSetupSetScore');
     scoreDisplay.classList.remove('hidden');
-    scoreDisplay.innerHTML = `Match Score: <strong>${state.team1Name}</strong> ${state.team1Sets} - ${state.team2Sets} <strong>${state.team2Name}</strong>`;
+    scoreDisplay.innerHTML = `Match Score: <strong>${escapeHtml(state.team1Name)}</strong> ${state.team1Sets} - ${state.team2Sets} <strong>${escapeHtml(state.team2Name)}</strong>`;
+    updatePrevRotationButtons();
+    initDragAndDrop();
+}
+
+function updatePrevRotationButtons() {
+    const btn1 = document.querySelector('.use-prev-rotation[data-team="1"]');
+    const btn2 = document.querySelector('.use-prev-rotation[data-team="2"]');
+    if (btn1) btn1.style.display = state.lastStartingRotation1 ? '' : 'none';
+    if (btn2) btn2.style.display = state.lastStartingRotation2 ? '' : 'none';
 }
 
 function updateAvailablePlayers(team) {
@@ -681,7 +949,7 @@ function updateAvailablePlayers(team) {
 
     const usedPlayers = Object.values(rotation).filter(p => p !== null);
 
-    let html = '';
+    container.innerHTML = '';
     players.forEach(player => {
         if (player === libero) return;
 
@@ -691,13 +959,13 @@ function updateAvailablePlayers(team) {
         if (isUsed) classes.push('used');
         if (isCaptain) classes.push('captain');
 
-        html += `<span class="${classes.join(' ')}" data-team="${team}" data-player="${player}">${player}</span>`;
-    });
-
-    container.innerHTML = html;
-
-    container.querySelectorAll('.available-player:not(.used)').forEach(el => {
-        el.addEventListener('click', handlePlayerSelect);
+        const el = document.createElement('span');
+        el.className = classes.join(' ');
+        el.dataset.team = team;
+        el.dataset.player = player;
+        el.textContent = player;
+        if (!isUsed) el.addEventListener('click', handlePlayerSelect);
+        container.appendChild(el);
     });
 }
 
@@ -777,7 +1045,7 @@ function confirmRotationSetup() {
     const errorDiv = document.getElementById('rotationSetupError');
     if (errors.length > 0) {
         errorDiv.innerHTML = '<strong>Please fix the following:</strong><ul>' +
-            errors.map(e => `<li>${e}</li>`).join('') + '</ul>';
+            errors.map(e => `<li>${escapeHtml(e)}</li>`).join('') + '</ul>';
         errorDiv.classList.remove('hidden');
         return;
     }
@@ -801,6 +1069,9 @@ function confirmRotationSetup() {
         rotationSetupState.team2Rotation[6]
     ];
 
+    state.lastStartingRotation1 = [...state.team1Rotation];
+    state.lastStartingRotation2 = [...state.team2Rotation];
+
     document.getElementById('rotationSetup').classList.add('hidden');
     
     if (rotationSetupState.isNewSet) {
@@ -816,7 +1087,17 @@ function confirmRotationSetup() {
 }
 
 function beginMatch() {
+    const savedR1 = state.team1Rotation.slice();
+    const savedR2 = state.team2Rotation.slice();
+    const savedHasRotation = state.hasRotation;
+    const savedLast1 = state.lastStartingRotation1;
+    const savedLast2 = state.lastStartingRotation2;
     resetMatchState();
+    state.team1Rotation = savedR1;
+    state.team2Rotation = savedR2;
+    state.hasRotation = savedHasRotation;
+    state.lastStartingRotation1 = savedLast1;
+    state.lastStartingRotation2 = savedLast2;
 
     document.getElementById('setup').classList.add('hidden');
     document.getElementById('rotationSetup').classList.add('hidden');
@@ -850,6 +1131,15 @@ function resetMatchState() {
     state.matchOver = false;
     state.team1OriginalId = 'A';
     state.team2OriginalId = 'B';
+    state.team1Rotation = [];
+    state.team2Rotation = [];
+    state.team1Subs = {};
+    state.team2Subs = {};
+    state.team1LiberoIn = null;
+    state.team2LiberoIn = null;
+    state.hasRotation = false;
+    state.lastStartingRotation1 = null;
+    state.lastStartingRotation2 = null;
 }
 
 function resetToSetup() {
@@ -885,6 +1175,7 @@ function addPoint(team) {
         team2LiberoIn: state.team2LiberoIn
     });
 
+    _scorePulseTeam = team;
     if (team === 1) {
         state.team1Score++;
     } else {
@@ -935,7 +1226,8 @@ function checkSetWin() {
             team1Score: state.team1Score,
             team2Score: state.team2Score,
             winner: setWinner,
-            winnerOriginalId: winnerOriginalId
+            winnerOriginalId: winnerOriginalId,
+            points: [...state.currentSetPoints]
         });
 
         if (setWinner === 1) {
@@ -967,6 +1259,73 @@ function checkSetWin() {
     }
 }
 
+function renderSetChart(set) {
+    const pts = set.points;
+    if (!pts || pts.length < 2) return '';
+
+    const w = 280, dataH = 78, padX = 4, padY = 6, tickZone = 18;
+    const svgH = dataH + tickZone;
+    const allPts = [{ team1Score: 0, team2Score: 0 }, ...pts];
+    const n = allPts.length - 1;
+    const maxScore = Math.max(set.team1Score, set.team2Score, 1);
+
+    const cssStyle = getComputedStyle(document.documentElement);
+    const colorA = cssStyle.getPropertyValue('--team1-color').trim();
+    const colorB = cssStyle.getPropertyValue('--team2-color').trim();
+    const rgbA   = cssStyle.getPropertyValue('--team1-rgb').trim();
+    const rgbB   = cssStyle.getPropertyValue('--team2-rgb').trim();
+    const team1Color = state.team1OriginalId === 'A' ? colorA : colorB;
+    const team1Rgb   = state.team1OriginalId === 'A' ? rgbA   : rgbB;
+    const team2Color = state.team2OriginalId === 'A' ? colorA : colorB;
+    const team2Rgb   = state.team2OriginalId === 'A' ? rgbA   : rgbB;
+
+    const toX = i => (padX + (n > 0 ? (i / n) * (w - 2 * padX) : 0)).toFixed(1);
+    const toY = s => ((dataH - padY) - (s / maxScore) * (dataH - 2 * padY)).toFixed(1);
+
+    // Per-segment lines — trailing team rendered at low opacity each interval
+    let lines1 = '', lines2 = '';
+    for (let i = 1; i <= n; i++) {
+        const prev = allPts[i - 1], cur = allPts[i];
+        const x1 = toX(i - 1), x2 = toX(i);
+        const op1 = prev.team1Score < prev.team2Score ? '0.28' : '1';
+        const op2 = prev.team2Score < prev.team1Score ? '0.28' : '1';
+        lines1 += `<line x1="${x1}" y1="${toY(prev.team1Score)}" x2="${x2}" y2="${toY(cur.team1Score)}" stroke="${team1Color}" stroke-width="2.5" stroke-opacity="${op1}" stroke-linecap="round"/>`;
+        lines2 += `<line x1="${x1}" y1="${toY(prev.team2Score)}" x2="${x2}" y2="${toY(cur.team2Score)}" stroke="${team2Color}" stroke-width="2.5" stroke-opacity="${op2}" stroke-linecap="round"/>`;
+    }
+
+    // Score markers — tick at each 5-point score milestone (labels show score, not rally count)
+    let ticks = '';
+    for (let score = 5; score <= maxScore; score += 5) {
+        const idx = allPts.findIndex(p => Math.max(p.team1Score, p.team2Score) >= score);
+        if (idx > 0) {
+            const x = toX(idx);
+            ticks += `<line x1="${x}" y1="${dataH - 1}" x2="${x}" y2="${dataH + 4}" stroke="rgba(255,255,255,0.2)" stroke-width="1"/>`;
+            ticks += `<text x="${x}" y="${svgH - 2}" text-anchor="middle" font-size="8" fill="rgba(255,255,255,0.38)" font-family="Barlow Semi Condensed,sans-serif">${score}</text>`;
+        }
+    }
+
+    const winnerOriginalId = set.winnerOriginalId || (set.winner === 1 ? 'A' : 'B');
+    const winLabel = winnerOriginalId === state.team1OriginalId ? state.team1Name : state.team2Name;
+    const winColor = winnerOriginalId === state.team1OriginalId ? team1Color : team2Color;
+
+    return `
+        <div class="set-chart-wrap">
+            <div class="set-chart-header">
+                <span class="set-chart-label">Set ${set.set}</span>
+                <span class="set-chart-score">${set.team1Score} – ${set.team2Score}</span>
+                <span class="set-chart-winner" style="color:${winColor}">${escapeHtml(winLabel)}</span>
+            </div>
+            <svg viewBox="0 0 ${w} ${svgH}" class="set-chart" preserveAspectRatio="none">
+                ${lines1}${lines2}${ticks}
+            </svg>
+            <div class="set-chart-axis">
+                <span style="color:${team1Color}">${escapeHtml(state.team1Name)}</span>
+                <span style="color:${team2Color}">${escapeHtml(state.team2Name)}</span>
+            </div>
+        </div>
+    `;
+}
+
 function endMatch() {
     state.matchOver = true;
     const winner = state.team1Sets > state.team2Sets ? state.team1Name : state.team2Name;
@@ -976,13 +1335,24 @@ function endMatch() {
 
     document.getElementById('winner').textContent = `${winner} Wins!`;
 
-    let scoreHTML = `<div>Final: ${state.team1Sets} - ${state.team2Sets}</div>`;
-    scoreHTML += '<div style="margin-top: 15px;">';
+    const totalT1 = state.setHistory.reduce((a, s) => a + s.team1Score, 0);
+    const totalT2 = state.setHistory.reduce((a, s) => a + s.team2Score, 0);
+
+    let scoreHTML = `<div class="final-summary">Final: ${state.team1Sets} – ${state.team2Sets}</div>`;
+    scoreHTML += `<div class="total-points">${escapeHtml(state.team1Name)} ${totalT1} pts &nbsp;·&nbsp; ${escapeHtml(state.team2Name)} ${totalT2} pts</div>`;
+    scoreHTML += '<div class="set-results-row">';
     state.setHistory.forEach(set => {
         const winnerClass = set.winner === 1 ? 'team1-win' : 'team2-win';
         scoreHTML += `<span class="set-result ${winnerClass}">Set ${set.set}: ${set.team1Score}-${set.team2Score}</span>`;
     });
     scoreHTML += '</div>';
+
+    scoreHTML += '<div class="set-charts">';
+    state.setHistory.forEach(set => {
+        scoreHTML += renderSetChart(set);
+    });
+    scoreHTML += '</div>';
+
     document.getElementById('finalScore').innerHTML = scoreHTML;
 }
 
@@ -1056,20 +1426,19 @@ function updateRotationDisplay(team, rotation, captain, libero, isServing) {
 function updateRotationSetupColors() {
     const rotationTeam1Name = document.getElementById('rotationTeam1Name');
     const rotationTeam2Name = document.getElementById('rotationTeam2Name');
-    
+
     if (!rotationTeam1Name || !rotationTeam2Name) return;
-    
-    // Team A is blue (#667eea), Team B is red (#f5576c)
-    const blueColor = '#667eea';
-    const redColor = '#f5576c';
-    
-    // Apply colors based on original team identity
+
+    const style = getComputedStyle(document.documentElement);
+    const team1Color = style.getPropertyValue('--team1-color').trim();
+    const team2Color = style.getPropertyValue('--team2-color').trim();
+
     if (state.team1OriginalId === 'A') {
-        rotationTeam1Name.style.color = blueColor;
-        rotationTeam2Name.style.color = redColor;
+        rotationTeam1Name.style.color = team1Color;
+        rotationTeam2Name.style.color = team2Color;
     } else {
-        rotationTeam1Name.style.color = redColor;
-        rotationTeam2Name.style.color = blueColor;
+        rotationTeam1Name.style.color = team2Color;
+        rotationTeam2Name.style.color = team1Color;
     }
 }
 
@@ -1081,41 +1450,51 @@ function updateTeamColors() {
     const timeline1 = document.querySelector('.timeline-team:first-child');
     const timeline2 = document.querySelector('.timeline-team:last-child');
     
-    // Team A is blue (#667eea), Team B is red (#f5576c)
-    const blueColor = '#667eea';
-    const redColor = '#f5576c';
-    
-    // Apply colors based on original team identity, not position
+    const cssStyle = getComputedStyle(document.documentElement);
+    const team1Color = cssStyle.getPropertyValue('--team1-color').trim();
+    const team2Color = cssStyle.getPropertyValue('--team2-color').trim();
+
+    const team1RgbVal = cssStyle.getPropertyValue('--team1-rgb').trim();
+    const team2RgbVal = cssStyle.getPropertyValue('--team2-rgb').trim();
+
+    const applyTeamStyle = (container, scoreEl, color, rgbVal, timelineEl, timelineClass) => {
+        container.style.borderColor = color;
+        container.style.boxShadow = `inset 0 0 30px rgba(${rgbVal}, 0.06), 0 0 0 1px rgba(${rgbVal}, 0.08)`;
+        container.style.setProperty('--this-team-rgb', rgbVal);
+        scoreEl.style.color = color;
+        scoreEl.style.textShadow = `0 0 32px rgba(${rgbVal}, 0.4)`;
+        if (timelineEl) timelineEl.setAttribute('data-team-color', timelineClass);
+    };
+
     if (state.team1OriginalId === 'A') {
-        // Team A is in position 1 (left)
-        team1Container.style.borderColor = blueColor;
-        team1ScoreEl.style.color = blueColor;
-        team2Container.style.borderColor = redColor;
-        team2ScoreEl.style.color = redColor;
-        
-        // Update timeline colors
-        if (timeline1) timeline1.setAttribute('data-team-color', 'blue');
-        if (timeline2) timeline2.setAttribute('data-team-color', 'red');
+        applyTeamStyle(team1Container, team1ScoreEl, team1Color, team1RgbVal, timeline1, 'team1');
+        applyTeamStyle(team2Container, team2ScoreEl, team2Color, team2RgbVal, timeline2, 'team2');
     } else {
-        // Team B is in position 1 (left), Team A is in position 2 (right)
-        team1Container.style.borderColor = redColor;
-        team1ScoreEl.style.color = redColor;
-        team2Container.style.borderColor = blueColor;
-        team2ScoreEl.style.color = blueColor;
-        
-        // Update timeline colors
-        if (timeline1) timeline1.setAttribute('data-team-color', 'red');
-        if (timeline2) timeline2.setAttribute('data-team-color', 'blue');
+        applyTeamStyle(team1Container, team1ScoreEl, team2Color, team2RgbVal, timeline1, 'team2');
+        applyTeamStyle(team2Container, team2ScoreEl, team1Color, team1RgbVal, timeline2, 'team1');
     }
+}
+
+function pulseScore(el) {
+    el.classList.remove('pulse');
+    void el.offsetWidth;
+    el.classList.add('pulse');
+    el.addEventListener('animationend', () => el.classList.remove('pulse'), { once: true });
 }
 
 function updateDisplay() {
     updateTeamColors();
-    
+
     document.getElementById('team1Display').textContent = state.team1Name;
     document.getElementById('team2Display').textContent = state.team2Name;
-    document.getElementById('team1Score').textContent = state.team1Score;
-    document.getElementById('team2Score').textContent = state.team2Score;
+
+    const t1El = document.getElementById('team1Score');
+    const t2El = document.getElementById('team2Score');
+    t1El.textContent = state.team1Score;
+    t2El.textContent = state.team2Score;
+    if (_scorePulseTeam === 1) pulseScore(t1El);
+    else if (_scorePulseTeam === 2) pulseScore(t2El);
+    _scorePulseTeam = null;
     let setsHTML = '';
     if (state.setHistory.length === 0) {
         setsHTML = '<span class="no-sets">No sets completed</span>';

--- a/index.html
+++ b/index.html
@@ -6,8 +6,13 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="mobile-web-app-capable" content="yes">
-    <meta name="theme-color" content="#1a1a2e">
+    <meta name="theme-color" content="#071545">
     <title>Volleyball Referee</title>
+    <link rel="icon" type="image/png" href="icons/volleyball.png">
+    <link rel="apple-touch-icon" href="icons/volleyball.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Barlow+Semi+Condensed:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-RBPL9H3D0Y"></script>
@@ -33,16 +38,28 @@
                     </div>
                     <div class="team-input">
                         <label for="team1Players">Jersey Numbers (comma separated):</label>
-                        <input type="text" id="team1Players" placeholder="1, 2, 3, 4, 5, 6">
+                        <input type="text" id="team1Players" placeholder="1, 2, A, ⚡, 10">
                     </div>
                     <div class="team-input-row">
                         <div class="team-input">
                             <label for="team1Captain">Captain #:</label>
-                            <input type="number" id="team1Captain" placeholder="Cap">
+                            <input type="text" id="team1Captain" placeholder="Cap" maxlength="3">
                         </div>
                         <div class="team-input">
                             <label for="team1Libero">Libero #:</label>
-                            <input type="number" id="team1Libero" placeholder="Lib">
+                            <input type="text" id="team1Libero" placeholder="Lib" maxlength="3">
+                        </div>
+                    </div>
+                    <div class="color-picker-row">
+                        <label>Color:</label>
+                        <input type="color" id="team1Color" value="#2979ff">
+                        <div class="color-presets">
+                            <button class="color-swatch" data-team="1" data-color="#2979ff" style="background:#2979ff" title="Blue"></button>
+                            <button class="color-swatch" data-team="1" data-color="#00b0ff" style="background:#00b0ff" title="Sky blue"></button>
+                            <button class="color-swatch" data-team="1" data-color="#00c853" style="background:#00c853" title="Green"></button>
+                            <button class="color-swatch" data-team="1" data-color="#f5c842" style="background:#f5c842" title="Yellow"></button>
+                            <button class="color-swatch" data-team="1" data-color="#ffffff" style="background:#ffffff" title="White"></button>
+                            <button class="color-swatch" data-team="1" data-color="#ff8f00" style="background:#ff8f00" title="Orange"></button>
                         </div>
                     </div>
                 </div>
@@ -54,16 +71,28 @@
                     </div>
                     <div class="team-input">
                         <label for="team2Players">Jersey Numbers (comma separated):</label>
-                        <input type="text" id="team2Players" placeholder="1, 2, 3, 4, 5, 6">
+                        <input type="text" id="team2Players" placeholder="1, 2, A, ⚡, 10">
                     </div>
                     <div class="team-input-row">
                         <div class="team-input">
                             <label for="team2Captain">Captain #:</label>
-                            <input type="number" id="team2Captain" placeholder="Cap">
+                            <input type="text" id="team2Captain" placeholder="Cap" maxlength="3">
                         </div>
                         <div class="team-input">
                             <label for="team2Libero">Libero #:</label>
-                            <input type="number" id="team2Libero" placeholder="Lib">
+                            <input type="text" id="team2Libero" placeholder="Lib" maxlength="3">
+                        </div>
+                    </div>
+                    <div class="color-picker-row">
+                        <label>Color:</label>
+                        <input type="color" id="team2Color" value="#ff8f00">
+                        <div class="color-presets">
+                            <button class="color-swatch" data-team="2" data-color="#ff8f00" style="background:#ff8f00" title="Orange"></button>
+                            <button class="color-swatch" data-team="2" data-color="#c62828" style="background:#c62828" title="Red"></button>
+                            <button class="color-swatch" data-team="2" data-color="#e040fb" style="background:#e040fb" title="Purple"></button>
+                            <button class="color-swatch" data-team="2" data-color="#f5c842" style="background:#f5c842" title="Yellow"></button>
+                            <button class="color-swatch" data-team="2" data-color="#ffffff" style="background:#ffffff" title="White"></button>
+                            <button class="color-swatch" data-team="2" data-color="#2979ff" style="background:#2979ff" title="Blue"></button>
                         </div>
                     </div>
                 </div>
@@ -103,6 +132,7 @@
                         </div>
                     </div>
                     <div class="available-players" id="availablePlayers1"></div>
+                    <button class="btn btn-secondary use-prev-rotation" data-team="1" style="display:none">Use previous rotation</button>
                 </div>
                 <div class="rotation-setup-team">
                     <h3 id="rotationTeam2Name">Team B</h3>
@@ -119,6 +149,7 @@
                         </div>
                     </div>
                     <div class="available-players" id="availablePlayers2"></div>
+                    <button class="btn btn-secondary use-prev-rotation" data-team="2" style="display:none">Use previous rotation</button>
                 </div>
             </div>
             <div id="rotationSetupError" class="setup-error hidden"></div>
@@ -218,7 +249,7 @@
 
             
             <div class="controls">
-                <button id="newMatch" class="btn btn-danger">New Match</button>
+                <button id="returnToSetup" class="btn btn-secondary">Return to Setup</button>
             </div>
         </div>
 
@@ -267,20 +298,20 @@
         </div>
     </div>
 
-    <div id="newMatchModal" class="modal hidden">
+    <div id="returnToSetupModal" class="modal hidden">
         <div class="modal-content">
-            <div class="confirm-icon">⚠️</div>
-            <h2>Start New Match?</h2>
-            <p class="confirm-subtitle">All current match data will be lost.</p>
-            <div class="confirm-score-summary" id="confirmScoreSummary"></div>
+            <div class="confirm-icon">↩️</div>
+            <h2>Return to Setup?</h2>
+            <p class="confirm-subtitle">The current match will be cancelled.</p>
+            <div class="confirm-score-summary" id="returnToSetupScoreSummary"></div>
             <div class="confirm-buttons">
-                <button class="btn btn-secondary" id="cancelNewMatch">Cancel</button>
-                <button class="btn btn-danger" id="confirmNewMatch">New Match</button>
+                <button class="btn btn-secondary" id="cancelReturnToSetup">Cancel</button>
+                <button class="btn btn-danger" id="confirmReturnToSetup">Return to Setup</button>
             </div>
         </div>
     </div>
 
-    <footer class="credits">v2.12 | Created by Menon Pranto</footer>
+    <footer class="credits">v3.0 | Created by Menon Pranto</footer>
 
     <script src="app.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -765,6 +765,10 @@ h1 {
     justify-content: center;
 }
 
+.use-prev-rotation {
+    margin-top: 10px;
+}
+
 .available-player {
     width: 42px;
     height: 42px;

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,55 @@
+/* ─────────────────────────────────────────────────────────────────────────
+   VOLLEYBALL REFEREE  ·  Design System
+   Theme: Indoor Court / Mikasa — Stadium Night
+   ───────────────────────────────────────────────────────────────────────── */
+
+:root {
+    /* ── team identity (user-customizable later via #15) ── */
+    --team1-color: #2979ff;
+    --team1-rgb: 41, 121, 255;
+    --team2-color: #ff8f00;
+    --team2-rgb: 255, 143, 0;
+
+    /* ── court & brand chrome (not user-editable) ── */
+    --court-bg-deep:   #0d2055;
+    --court-bg-warm:   #152b7a;
+    --court-bg-mid:    #1a348f;
+    --court-gold:      #f5c842;
+    --court-gold-dim:  rgba(245, 200, 66, 0.18);
+    --court-cream:     #ffffff;
+    --court-cream-dim: rgba(255, 255, 255, 0.7);
+    --court-cream-off: rgba(255, 255, 255, 0.35);
+    --mikasa-yellow:   #f5c842;
+
+    /* ── panels ── */
+    --panel-bg:     rgba(255, 255, 255, 0.04);
+    --panel-border: rgba(255, 255, 255, 0.12);
+    --panel-shadow: 0 16px 64px rgba(0, 0, 0, 0.6), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+
+    /* ── modal ── */
+    --modal-bg: linear-gradient(160deg, #0f2060 0%, #0c1a50 100%);
+
+    /* ── buttons ── */
+    --btn-primary:   linear-gradient(135deg, #f5c842 0%, #d4a017 100%);
+    --btn-danger:    linear-gradient(135deg, #d33030 0%, #8b1a1a 100%);
+    --btn-score:     linear-gradient(135deg, #2e8b37 0%, #1b5e20 100%);
+    --btn-secondary-bg: rgba(255, 255, 255, 0.08);
+    --btn-secondary-border: rgba(255, 255, 255, 0.2);
+
+    /* ── typography ── */
+    --font-display: 'Bebas Neue', 'Arial Narrow', Arial, sans-serif;
+    --font-body:    'Barlow Semi Condensed', 'Segoe UI', system-ui, sans-serif;
+
+    /* ── functional ── */
+    --danger:       #c62828;
+    --error-bg:     rgba(198, 40, 40, 0.12);
+    --error-border: rgba(198, 40, 40, 0.4);
+    --error-text:   #f48a8a;
+    --libero-color: #4caf50;
+}
+
+/* ── Reset ───────────────────────────────────────────────────────────────── */
+
 * {
     margin: 0;
     padding: 0;
@@ -10,12 +62,18 @@ html {
     overflow-x: hidden;
 }
 
+/* ── Base ────────────────────────────────────────────────────────────────── */
+
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+    font-family: var(--font-body);
+    font-weight: 400;
+    background:
+        radial-gradient(ellipse at 20% 15%, rgba(100, 160, 255, 0.15) 0%, transparent 55%),
+        radial-gradient(ellipse at 80% 85%, rgba(245, 200, 66, 0.08) 0%, transparent 50%),
+        linear-gradient(170deg, var(--court-bg-mid) 0%, var(--court-bg-warm) 40%, var(--court-bg-deep) 100%);
     min-height: 100vh;
     min-height: -webkit-fill-available;
-    color: #fff;
+    color: var(--court-cream);
     padding-top: env(safe-area-inset-top);
     padding-bottom: env(safe-area-inset-bottom);
     padding-left: env(safe-area-inset-left);
@@ -23,7 +81,44 @@ body {
     overflow-x: hidden;
 }
 
+/* subtle court-line geometry in background */
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    opacity: 1;
+    background-image:
+        /* center net line (horizontal) */
+        linear-gradient(0deg,
+            transparent 49.6%,
+            rgba(255, 255, 255, 0.045) 50%,
+            transparent 50.4%),
+        /* left sideline */
+        linear-gradient(90deg,
+            transparent 7.5%,
+            rgba(255, 255, 255, 0.03) 8%,
+            transparent 8.5%),
+        /* right sideline */
+        linear-gradient(90deg,
+            transparent 91.5%,
+            rgba(255, 255, 255, 0.03) 92%,
+            transparent 92.5%),
+        /* attack lines */
+        linear-gradient(0deg,
+            transparent 28.5%,
+            rgba(255, 255, 255, 0.022) 29%,
+            transparent 29.5%),
+        linear-gradient(0deg,
+            transparent 70.5%,
+            rgba(255, 255, 255, 0.022) 71%,
+            transparent 71.5%);
+}
+
 .container {
+    position: relative;
+    z-index: 1;
     max-width: 800px;
     margin: 0 auto;
     padding: 15px;
@@ -31,27 +126,41 @@ body {
 }
 
 h1 {
+    font-family: var(--font-display);
+    font-weight: 400;
     text-align: center;
-    margin-bottom: 30px;
-    font-size: 2.5rem;
-    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+    margin-bottom: 28px;
+    font-size: 3.2rem;
+    letter-spacing: 0.1em;
+    color: var(--court-cream);
+    text-shadow:
+        0 0 40px rgba(245, 200, 66, 0.35),
+        0 2px 12px rgba(0, 0, 0, 0.7);
 }
 
 .hidden {
     display: none !important;
 }
 
-/* Setup Panel */
+/* ── Setup Panel ─────────────────────────────────────────────────────────── */
+
 .setup-panel {
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 15px;
-    padding: 30px;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 16px;
+    padding: 32px;
     backdrop-filter: blur(10px);
+    box-shadow: var(--panel-shadow);
 }
 
 .setup-panel h2 {
+    font-family: var(--font-display);
+    font-weight: 400;
+    letter-spacing: 0.08em;
+    font-size: 2rem;
     text-align: center;
-    margin-bottom: 25px;
+    margin-bottom: 28px;
+    color: var(--court-cream);
 }
 
 .team-setup-container {
@@ -66,28 +175,33 @@ h1 {
     min-width: 250px;
     padding: 20px;
     border-radius: 12px;
-    background: rgba(255, 255, 255, 0.05);
+    background: rgba(255, 255, 255, 0.04);
 }
 
 .team1-setup {
-    border: 2px solid rgba(102, 126, 234, 0.5);
+    border: 1px solid rgba(var(--team1-rgb), 0.45);
+    box-shadow: inset 0 0 20px rgba(var(--team1-rgb), 0.04);
 }
 
 .team2-setup {
-    border: 2px solid rgba(245, 87, 108, 0.5);
+    border: 1px solid rgba(var(--team2-rgb), 0.45);
+    box-shadow: inset 0 0 20px rgba(var(--team2-rgb), 0.04);
 }
 
 .team-setup h3 {
-    margin-bottom: 15px;
-    font-size: 1.1rem;
+    font-family: var(--font-display);
+    font-weight: 400;
+    letter-spacing: 0.06em;
+    margin-bottom: 16px;
+    font-size: 1.4rem;
 }
 
 .team1-setup h3 {
-    color: #667eea;
+    color: var(--team1-color);
 }
 
 .team2-setup h3 {
-    color: #f5576c;
+    color: var(--team2-color);
 }
 
 .team-input {
@@ -101,23 +215,35 @@ h1 {
 .team-input label {
     display: block;
     margin-bottom: 6px;
-    font-weight: 500;
-    font-size: 0.9rem;
+    font-weight: 600;
+    font-size: 0.82rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--court-cream-dim);
 }
 
 .team-input input {
     width: 100%;
     padding: 10px 12px;
-    border: none;
+    border: 1px solid rgba(255, 255, 255, 0.25);
     border-radius: 8px;
     font-size: 1rem;
-    background: rgba(255, 255, 255, 0.9);
-    color: #333;
+    font-family: var(--font-body);
+    font-weight: 500;
+    background: rgba(255, 255, 255, 0.92);
+    color: #0d1a40;
     box-sizing: border-box;
+    transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.team-input input:focus {
+    outline: none;
+    border-color: var(--court-gold);
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.1);
 }
 
 .team-input input::placeholder {
-    color: #999;
+    color: #7a8aa8;
 }
 
 .team-input-row {
@@ -140,13 +266,14 @@ h1 {
 }
 
 .setup-error {
-    background: rgba(245, 87, 108, 0.2);
-    border: 1px solid #f5576c;
+    background: var(--error-bg);
+    border: 1px solid var(--error-border);
     border-radius: 8px;
     padding: 12px 15px;
     margin-bottom: 15px;
-    color: #f5576c;
+    color: var(--error-text);
     font-size: 0.9rem;
+    font-weight: 500;
 }
 
 .setup-error.hidden {
@@ -163,13 +290,17 @@ h1 {
 }
 
 .match-type {
-    margin-bottom: 25px;
+    margin-bottom: 26px;
 }
 
 .match-type > label {
     display: block;
     margin-bottom: 10px;
-    font-weight: 500;
+    font-weight: 600;
+    font-size: 0.82rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--court-cream-dim);
 }
 
 .radio-group {
@@ -183,110 +314,148 @@ h1 {
     align-items: center;
     gap: 8px;
     cursor: pointer;
+    font-weight: 500;
+    color: var(--court-cream-dim);
+    transition: color 0.2s;
+}
+
+.radio-group label:hover {
+    color: var(--court-cream);
 }
 
 .radio-group input[type="radio"] {
     width: 18px;
     height: 18px;
     cursor: pointer;
+    accent-color: var(--court-gold);
 }
 
-/* Buttons */
+/* ── Buttons ─────────────────────────────────────────────────────────────── */
+
 .btn {
     padding: 12px 24px;
     border: none;
     border-radius: 8px;
     font-size: 1rem;
-    font-weight: 600;
+    font-family: var(--font-body);
+    font-weight: 700;
+    letter-spacing: 0.03em;
     cursor: pointer;
-    transition: transform 0.2s, box-shadow 0.2s;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
 }
 
 .btn:hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+    filter: brightness(1.08);
 }
 
 .btn:active {
-    transform: scale(0.98);
+    transform: scale(0.97) translateY(0);
+    filter: brightness(0.95);
 }
 
 @media (hover: none) {
     .btn:hover {
         transform: none;
         box-shadow: none;
+        filter: none;
     }
 }
 
 .btn-primary {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: #fff;
+    background: var(--btn-primary);
+    color: #0d1a40;
     width: 100%;
+    box-shadow: 0 4px 16px rgba(245, 200, 66, 0.3);
 }
 
 .btn-secondary {
-    background: rgba(255, 255, 255, 0.2);
-    color: #fff;
+    background: var(--btn-secondary-bg);
+    border: 1px solid var(--btn-secondary-border);
+    color: var(--court-cream);
 }
 
 .btn-danger {
-    background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+    background: var(--btn-danger);
     color: #fff;
+    box-shadow: 0 4px 16px rgba(198, 40, 40, 0.3);
 }
 
 .btn-score {
-    background: linear-gradient(135deg, #11998e 0%, #38ef7d 100%);
+    background: var(--btn-score);
     color: #fff;
-    margin-top: 15px;
+    margin-top: 14px;
     width: 100%;
+    font-size: 1rem;
+    box-shadow: 0 4px 14px rgba(46, 139, 55, 0.3);
 }
 
-/* Scoreboard */
+/* ── Scoreboard ──────────────────────────────────────────────────────────── */
+
 .scoreboard {
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 15px;
-    padding: 30px;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 16px;
+    padding: 28px;
     backdrop-filter: blur(10px);
+    box-shadow: var(--panel-shadow);
 }
 
 .match-info {
     display: flex;
     justify-content: space-between;
     margin-bottom: 20px;
-    padding: 10px 15px;
-    background: rgba(0, 0, 0, 0.2);
+    padding: 10px 16px;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.08);
     border-radius: 8px;
-    font-size: 0.9rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--court-cream-dim);
 }
 
 .current-set {
     display: flex;
     justify-content: space-around;
     align-items: center;
-    gap: 20px;
-    margin-bottom: 30px;
+    gap: 16px;
+    margin-bottom: 28px;
 }
 
 .team {
     flex: 1;
     text-align: center;
     padding: 20px;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 15px;
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 14px;
+    transition: box-shadow 0.3s ease;
 }
 
 .team1 {
-    border: 3px solid #667eea;
+    border: 2px solid var(--team1-color);
+    box-shadow:
+        inset 0 0 30px rgba(var(--team1-rgb), 0.06),
+        0 0 0 1px rgba(var(--team1-rgb), 0.08);
 }
 
 .team2 {
-    border: 3px solid #f5576c;
+    border: 2px solid var(--team2-color);
+    box-shadow:
+        inset 0 0 30px rgba(var(--team2-rgb), 0.06),
+        0 0 0 1px rgba(var(--team2-rgb), 0.08);
 }
 
 .team-name {
-    font-size: 1.3rem;
-    font-weight: 600;
+    font-family: var(--font-display);
+    font-weight: 400;
+    font-size: 1.8rem;
+    letter-spacing: 0.06em;
     margin-bottom: 10px;
+    color: var(--court-cream);
+    line-height: 1.1;
 }
 
 .timeout-container {
@@ -294,45 +463,45 @@ h1 {
     align-items: center;
     justify-content: center;
     gap: 8px;
-    margin-bottom: 15px;
+    margin-bottom: 14px;
 }
 
 .timeout-btn {
-    background: rgba(255, 255, 255, 0.1);
-    border: none;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: 8px;
-    padding: 8px;
+    padding: 7px;
     cursor: pointer;
-    transition: background 0.2s, transform 0.2s;
+    transition: background 0.15s, transform 0.15s;
     display: flex;
     align-items: center;
     justify-content: center;
 }
 
 .timeout-btn:hover {
-    background: rgba(255, 255, 255, 0.2);
-    transform: scale(1.05);
+    background: rgba(255, 255, 255, 0.14);
+    transform: scale(1.06);
 }
 
 .timeout-btn:active {
-    transform: scale(0.95);
+    transform: scale(0.94);
 }
 
 .timeout-btn:disabled {
-    opacity: 0.4;
+    opacity: 0.35;
     cursor: not-allowed;
     transform: none;
 }
 
 .timeout-btn:disabled:hover {
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.06);
 }
 
 .timeout-icon {
     width: 24px;
     height: 24px;
-    filter: invert(1);
-    opacity: 0.9;
+    filter: invert(1) sepia(0.3) saturate(1.5) hue-rotate(5deg);
+    opacity: 0.85;
 }
 
 .timeout-dots {
@@ -345,25 +514,27 @@ h1 {
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    background: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.15);
     transition: background 0.3s, box-shadow 0.3s;
 }
 
 .timeout-dot.active {
-    background: #ffd700;
-    box-shadow: 0 0 8px #ffd700;
+    background: var(--mikasa-yellow);
+    box-shadow: 0 0 8px rgba(253, 216, 53, 0.6);
 }
 
-/* Rotation Grid */
+/* ── Rotation Grid ───────────────────────────────────────────────────────── */
+
 .rotation-grid.hidden {
     display: none;
 }
 
 .rotation-grid {
-    background: rgba(0, 0, 0, 0.2);
+    background: rgba(0, 0, 0, 0.25);
     border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.07);
     padding: 10px;
-    margin-bottom: 15px;
+    margin-bottom: 14px;
 }
 
 .rotation-row {
@@ -383,18 +554,21 @@ h1 {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.08);
     border-radius: 50%;
-    font-weight: 600;
-    font-size: 0.85rem;
-    transition: background 0.2s, transform 0.2s;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    font-family: var(--font-display);
+    font-weight: 400;
+    font-size: 1rem;
+    letter-spacing: 0.02em;
+    transition: background 0.15s, transform 0.15s;
     cursor: pointer;
     position: relative;
 }
 
 .rotation-pos:hover {
-    background: rgba(255, 255, 255, 0.2);
-    transform: scale(1.05);
+    background: rgba(255, 255, 255, 0.15);
+    transform: scale(1.06);
 }
 
 .rotation-pos .player-num {
@@ -402,22 +576,26 @@ h1 {
 }
 
 .rotation-pos .player-num.captain {
+    color: var(--mikasa-yellow);
     text-decoration: underline;
-    text-underline-offset: 2px;
+    text-underline-offset: 3px;
+    text-decoration-color: var(--mikasa-yellow);
 }
 
 .rotation-pos .sub-indicator {
     position: absolute;
     bottom: -2px;
     right: -2px;
-    font-size: 0.6rem;
-    background: rgba(0, 0, 0, 0.6);
+    font-size: 0.55rem;
+    font-family: var(--font-body);
+    background: rgba(0, 0, 0, 0.7);
     border-radius: 50%;
     width: 16px;
     height: 16px;
     display: none;
     align-items: center;
     justify-content: center;
+    color: var(--court-cream);
 }
 
 .rotation-pos .sub-indicator.visible {
@@ -425,52 +603,62 @@ h1 {
 }
 
 .rotation-pos.server {
-    background: rgba(255, 215, 0, 0.3);
-    box-shadow: 0 0 8px rgba(255, 215, 0, 0.5);
+    background: rgba(253, 216, 53, 0.2);
+    border-color: rgba(253, 216, 53, 0.5);
+    box-shadow: 0 0 10px rgba(253, 216, 53, 0.3);
 }
 
 .rotation-pos.libero-in {
-    background: rgba(76, 175, 80, 0.4);
+    background: rgba(76, 175, 80, 0.35);
+    border-color: rgba(76, 175, 80, 0.85);
+    box-shadow: 0 0 8px rgba(76, 175, 80, 0.4);
+    color: #81c784;
 }
 
-.team1 .rotation-pos {
-    border-color: rgba(102, 126, 234, 0.5);
-}
-
+.team1 .rotation-pos,
 .team2 .rotation-pos {
-    border-color: rgba(245, 87, 108, 0.5);
+    border-color: rgba(var(--this-team-rgb, 255, 255, 255), 0.3);
 }
 
 .front-row {
-    border-bottom: 1px dashed rgba(255, 255, 255, 0.2);
+    border-bottom: 1px dashed rgba(255, 255, 255, 0.12);
     padding-bottom: 6px;
 }
 
 .rotation-label {
     font-size: 0.7rem;
-    color: rgba(255, 255, 255, 0.5);
+    color: var(--court-cream-off);
     text-align: center;
     margin-bottom: 5px;
 }
 
-/* Rotation Setup */
+/* ── Rotation Setup ──────────────────────────────────────────────────────── */
+
 .rotation-setup {
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 15px;
-    padding: 30px;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 16px;
+    padding: 32px;
     backdrop-filter: blur(10px);
+    box-shadow: var(--panel-shadow);
 }
 
 .rotation-setup h2 {
+    font-family: var(--font-display);
+    font-weight: 400;
+    letter-spacing: 0.08em;
+    font-size: 2rem;
     text-align: center;
     margin-bottom: 10px;
+    color: var(--court-cream);
 }
 
 .rotation-setup-score {
     text-align: center;
-    margin-bottom: 15px;
-    font-size: 1.1rem;
-    color: rgba(255, 255, 255, 0.8);
+    margin-bottom: 16px;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--court-cream-dim);
 }
 
 .rotation-setup-score.hidden {
@@ -479,9 +667,10 @@ h1 {
 
 .rotation-setup-hint {
     text-align: center;
-    color: rgba(255, 255, 255, 0.6);
+    color: var(--court-cream-off);
     font-size: 0.9rem;
-    margin-bottom: 25px;
+    margin-bottom: 26px;
+    font-style: italic;
 }
 
 .rotation-setup-container {
@@ -489,7 +678,7 @@ h1 {
     gap: 30px;
     justify-content: center;
     flex-wrap: wrap;
-    margin-bottom: 25px;
+    margin-bottom: 26px;
 }
 
 .rotation-setup-team {
@@ -500,22 +689,27 @@ h1 {
 }
 
 .rotation-setup-team h3 {
-    margin-bottom: 15px;
+    font-family: var(--font-display);
+    font-weight: 400;
+    letter-spacing: 0.06em;
+    font-size: 1.6rem;
+    margin-bottom: 14px;
 }
 
 .rotation-setup-team:first-child h3 {
-    color: #667eea;
+    color: var(--team1-color);
 }
 
 .rotation-setup-team:last-child h3 {
-    color: #f5576c;
+    color: var(--team2-color);
 }
 
 .rotation-setup-grid {
-    background: rgba(0, 0, 0, 0.2);
+    background: rgba(0, 0, 0, 0.22);
+    border: 1px solid rgba(255, 255, 255, 0.07);
     border-radius: 12px;
-    padding: 15px;
-    margin-bottom: 15px;
+    padding: 14px;
+    margin-bottom: 14px;
 }
 
 .rotation-setup-row {
@@ -535,31 +729,33 @@ h1 {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(255, 255, 255, 0.1);
-    border: 2px dashed rgba(255, 255, 255, 0.3);
+    background: rgba(255, 255, 255, 0.06);
+    border: 2px dashed rgba(255, 255, 255, 0.22);
     border-radius: 50%;
-    font-weight: 600;
-    font-size: 0.8rem;
-    color: rgba(255, 255, 255, 0.4);
+    font-family: var(--font-display);
+    font-weight: 400;
+    font-size: 1rem;
+    color: var(--court-cream-off);
     cursor: pointer;
     transition: all 0.2s;
 }
 
 .rotation-setup-pos:hover {
-    background: rgba(255, 255, 255, 0.2);
-    border-color: rgba(255, 255, 255, 0.5);
+    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(255, 255, 255, 0.45);
 }
 
 .rotation-setup-pos.filled {
-    background: rgba(255, 255, 255, 0.15);
-    border: 2px solid rgba(255, 255, 255, 0.5);
-    color: #fff;
+    background: rgba(255, 255, 255, 0.1);
+    border: 2px solid rgba(255, 255, 255, 0.45);
+    color: var(--court-cream);
     font-size: 1rem;
 }
 
 .rotation-setup-pos.selected {
-    border-color: #ffd700;
-    box-shadow: 0 0 10px rgba(255, 215, 0, 0.5);
+    border-color: var(--mikasa-yellow);
+    border-style: solid;
+    box-shadow: 0 0 12px rgba(253, 216, 53, 0.4);
 }
 
 .available-players {
@@ -570,54 +766,65 @@ h1 {
 }
 
 .available-player {
-    width: 40px;
-    height: 40px;
+    width: 42px;
+    height: 42px;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(255, 255, 255, 0.1);
     border-radius: 50%;
-    font-weight: 600;
-    font-size: 0.9rem;
+    font-family: var(--font-display);
+    font-weight: 400;
+    font-size: 1.05rem;
     cursor: pointer;
     transition: all 0.2s;
 }
 
 .available-player:hover {
-    background: rgba(255, 255, 255, 0.25);
-    transform: scale(1.1);
+    transform: scale(1.12);
+    filter: brightness(1.2);
 }
 
 .available-player.used {
     opacity: 0.3;
     cursor: not-allowed;
+    transform: none;
+}
+
+.available-player.used:hover {
+    transform: none;
+    filter: none;
 }
 
 .available-player.captain {
-    border: 2px solid #ffd700;
+    box-shadow: 0 0 0 2px var(--mikasa-yellow);
 }
 
 .rotation-setup-team:first-child .available-player {
-    background: rgba(102, 126, 234, 0.3);
+    background: rgba(var(--team1-rgb), 0.28);
+    border: 1px solid rgba(var(--team1-rgb), 0.4);
+    color: rgba(var(--team1-rgb), 1);
 }
 
 .rotation-setup-team:last-child .available-player {
-    background: rgba(245, 87, 108, 0.3);
+    background: rgba(var(--team2-rgb), 0.28);
+    border: 1px solid rgba(var(--team2-rgb), 0.4);
+    color: rgba(var(--team2-rgb), 1);
 }
 
-/* Timeout Modal */
+/* ── Modals ──────────────────────────────────────────────────────────────── */
+
 .modal {
     position: fixed;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(0, 0, 0, 0.8);
+    background: rgba(0, 0, 0, 0.82);
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: 1000;
-    backdrop-filter: blur(5px);
+    backdrop-filter: blur(6px);
     padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
@@ -628,17 +835,24 @@ h1 {
 }
 
 .modal-content {
-    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+    background: var(--modal-bg);
+    border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: 20px;
     padding: 40px;
     text-align: center;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+    box-shadow:
+        0 24px 80px rgba(0, 0, 0, 0.7),
+        inset 0 1px 0 rgba(255, 225, 140, 0.08);
+    animation: modalIn 0.22s cubic-bezier(0.34, 1.4, 0.64, 1);
 }
 
 .modal-content h2 {
-    margin-bottom: 30px;
-    font-size: 1.5rem;
+    font-family: var(--font-display);
+    font-weight: 400;
+    letter-spacing: 0.08em;
+    margin-bottom: 28px;
+    font-size: 1.8rem;
+    color: var(--court-cream);
 }
 
 .timer-display {
@@ -662,11 +876,12 @@ h1 {
 
 .timer-ring-progress {
     fill: none;
-    stroke: #ffd700;
+    stroke: var(--mikasa-yellow);
     stroke-width: 8;
     stroke-linecap: round;
     stroke-dasharray: 283;
     stroke-dashoffset: 0;
+    filter: drop-shadow(0 0 6px rgba(253, 216, 53, 0.5));
 }
 
 .timer-text {
@@ -674,9 +889,11 @@ h1 {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    font-size: 3rem;
-    font-weight: 700;
-    color: #fff;
+    font-family: var(--font-display);
+    font-weight: 400;
+    font-size: 3.5rem;
+    letter-spacing: 0.04em;
+    color: var(--court-cream);
     font-variant-numeric: tabular-nums;
 }
 
@@ -684,18 +901,20 @@ h1 {
     max-width: 200px;
 }
 
-/* Substitution Modal */
+/* ── Substitution Modal ──────────────────────────────────────────────────── */
+
 .sub-modal-content {
     min-width: 280px;
 }
 
 .sub-modal-content h2 {
-    margin-bottom: 15px;
+    margin-bottom: 14px;
 }
 
 .sub-modal-content p {
-    color: rgba(255, 255, 255, 0.7);
+    color: var(--court-cream-dim);
     margin-bottom: 20px;
+    font-size: 0.95rem;
 }
 
 .sub-options {
@@ -716,57 +935,74 @@ h1 {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(255, 255, 255, 0.1);
-    border: 2px solid rgba(255, 255, 255, 0.3);
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.3);
     border-radius: 50%;
-    font-weight: 600;
-    font-size: 1rem;
+    font-family: var(--font-display);
+    font-weight: 400;
+    font-size: 1.1rem;
     cursor: pointer;
-    transition: all 0.2s;
+    transition: all 0.18s;
+    color: var(--court-cream);
 }
 
 .sub-option:hover {
-    background: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.18);
     transform: scale(1.1);
+    box-shadow: 0 0 12px rgba(255, 255, 255, 0.15);
 }
 
 .sub-option.libero {
-    background: rgba(76, 175, 80, 0.4);
-    border-color: rgba(76, 175, 80, 0.8);
+    background: rgba(76, 175, 80, 0.3);
+    border-color: rgba(76, 175, 80, 0.85);
+    color: #81c784;
 }
 
 .sub-option.libero:hover {
-    background: rgba(76, 175, 80, 0.6);
+    background: rgba(76, 175, 80, 0.4);
 }
 
 .sub-option.return-player {
-    background: rgba(255, 193, 7, 0.3);
-    border-color: rgba(255, 193, 7, 0.8);
+    background: rgba(253, 216, 53, 0.15);
+    border-color: rgba(253, 216, 53, 0.5);
 }
 
 .sub-option.disabled {
-    opacity: 0.3;
+    opacity: 0.28;
     cursor: not-allowed;
 }
 
 .sub-option.disabled:hover {
     transform: none;
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.08);
+    box-shadow: none;
 }
 
+/* ── Score Display ───────────────────────────────────────────────────────── */
+
 .score {
-    font-size: 5rem;
-    font-weight: 700;
+    font-family: var(--font-display);
+    font-weight: 400;
+    font-size: 6rem;
+    letter-spacing: 0.02em;
     line-height: 1;
 }
 
 .team1 .score {
-    color: #667eea;
+    color: var(--team1-color);
+    text-shadow: 0 0 32px rgba(var(--team1-rgb), 0.4);
 }
 
 .team2 .score {
-    color: #f5576c;
+    color: var(--team2-color);
+    text-shadow: 0 0 32px rgba(var(--team2-rgb), 0.4);
 }
+
+.score.pulse {
+    animation: scorePulse 0.32s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* ── VS Container ────────────────────────────────────────────────────────── */
 
 .vs-container {
     display: flex;
@@ -779,23 +1015,23 @@ h1 {
     cursor: pointer;
     padding: 10px;
     border-radius: 50%;
-    background: #fff;
-    transition: transform 0.2s, box-shadow 0.2s;
+    background: rgba(255, 255, 255, 0.9);
+    transition: transform 0.18s, box-shadow 0.18s;
     display: flex;
     align-items: center;
     justify-content: center;
     width: 44px;
     height: 44px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
 }
 
 .undo-btn:hover {
-    transform: scale(1.05);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    transform: scale(1.06);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.45);
 }
 
 .undo-btn:active {
-    transform: scale(0.95);
+    transform: scale(0.93);
 }
 
 .undo-icon {
@@ -807,23 +1043,23 @@ h1 {
     cursor: pointer;
     padding: 12px;
     border-radius: 50%;
-    background: #fff;
-    transition: transform 0.2s, box-shadow 0.2s;
+    background: rgba(255, 255, 255, 0.9);
+    transition: transform 0.18s, box-shadow 0.18s;
     display: flex;
     align-items: center;
     justify-content: center;
     width: 56px;
     height: 56px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
 }
 
 .swap-teams:hover {
-    transform: scale(1.05);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    transform: scale(1.06);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.45);
 }
 
 .swap-teams:active {
-    transform: scale(0.95);
+    transform: scale(0.93);
 }
 
 .swap-icon {
@@ -832,59 +1068,58 @@ h1 {
 }
 
 .vs {
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: rgba(255, 255, 255, 0.5);
+    font-family: var(--font-display);
+    font-weight: 400;
+    font-size: 2rem;
+    letter-spacing: 0.12em;
+    color: rgba(245, 200, 66, 0.6);
 }
 
 .sets-score-center {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 5px;
     align-items: center;
 }
 
 .set-score-item {
-    font-size: 1.1rem;
-    font-weight: 600;
-    padding: 5px 15px;
+    font-family: var(--font-body);
+    font-size: 1rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    padding: 4px 14px;
     border-radius: 6px;
-    background: rgba(255, 255, 255, 0.1);
-}
-
-.set-score-item.team1-set-win {
-    border-left: 3px solid #667eea;
-}
-
-.set-score-item.team2-set-win {
-    border-right: 3px solid #f5576c;
+    background: rgba(255, 255, 255, 0.07);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--court-cream-dim);
 }
 
 .set-score-item.teamA-set-win {
-    border-left: 3px solid #667eea;
+    border-left: 3px solid var(--team1-color);
 }
 
 .set-score-item.teamB-set-win {
-    border-right: 3px solid #f5576c;
+    border-right: 3px solid var(--team2-color);
 }
 
 .no-sets {
-    font-size: 0.85rem;
-    color: rgba(255, 255, 255, 0.4);
+    font-size: 0.82rem;
+    color: var(--court-cream-off);
 }
 
 .serve-indicator {
     width: 80px;
-    height: 40px;
+    height: 38px;
     cursor: pointer;
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: 20px;
     position: relative;
     transition: background 0.2s;
 }
 
 .serve-indicator:hover {
-    background: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.16);
 }
 
 .serve-ball {
@@ -893,28 +1128,36 @@ h1 {
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    transition: left 0.3s ease;
-    left: 5px;
+    transition: left 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+    left: 4px;
+    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.4));
 }
 
 .serve-ball.right {
-    left: calc(100% - 35px);
+    left: calc(100% - 34px);
 }
 
-/* Point Timeline */
+/* ── Point Timeline ──────────────────────────────────────────────────────── */
+
 .point-timeline {
-    margin-bottom: 25px;
+    margin-bottom: 24px;
 }
 
 .point-timeline h3 {
-    margin-bottom: 15px;
-    font-size: 1.1rem;
+    font-family: var(--font-body);
+    font-size: 0.82rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--court-cream-off);
+    margin-bottom: 12px;
 }
 
 .timeline-container {
-    background: rgba(0, 0, 0, 0.2);
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.07);
     border-radius: 8px;
-    padding: 15px;
+    padding: 14px;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
 }
@@ -922,17 +1165,17 @@ h1 {
 .timeline-team {
     display: flex;
     align-items: center;
-    min-height: 40px;
+    min-height: 38px;
 }
 
 .timeline-team:first-child {
-    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-    padding-bottom: 8px;
-    margin-bottom: 8px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    padding-bottom: 7px;
+    margin-bottom: 7px;
 }
 
 .timeline-label {
-    min-width: 24px;
+    min-width: 22px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -941,33 +1184,34 @@ h1 {
 .first-serve-icon {
     width: 18px;
     height: 18px;
+    opacity: 0.85;
 }
 
 .timeline-team:first-child .timeline-label {
-    color: #667eea;
+    color: var(--team1-color);
 }
 
 .timeline-team:last-child .timeline-label {
-    color: #f5576c;
+    color: var(--team2-color);
 }
 
 /* Dynamic timeline colors based on team identity */
-.timeline-team[data-team-color="blue"] .timeline-label {
-    color: #667eea;
+.timeline-team[data-team-color="team1"] .timeline-label {
+    color: var(--team1-color);
 }
 
-.timeline-team[data-team-color="red"] .timeline-label {
-    color: #f5576c;
+.timeline-team[data-team-color="team2"] .timeline-label {
+    color: var(--team2-color);
 }
 
-.timeline-team[data-team-color="blue"] .timeline-cell.scored {
-    background: rgba(102, 126, 234, 0.4);
-    color: #a8b5f0;
+.timeline-team[data-team-color="team1"] .timeline-cell.scored {
+    background: rgba(var(--team1-rgb), 0.32);
+    color: rgba(var(--team1-rgb), 0.95);
 }
 
-.timeline-team[data-team-color="red"] .timeline-cell.scored {
-    background: rgba(245, 87, 108, 0.4);
-    color: #f9a8b5;
+.timeline-team[data-team-color="team2"] .timeline-cell.scored {
+    background: rgba(var(--team2-rgb), 0.32);
+    color: rgba(var(--team2-rgb), 0.95);
 }
 
 .timeline-row {
@@ -976,19 +1220,21 @@ h1 {
 }
 
 .timeline-cell {
-    width: 32px;
-    height: 32px;
+    width: 30px;
+    height: 30px;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-weight: 600;
-    font-size: 0.9rem;
+    font-family: var(--font-display);
+    font-size: 0.95rem;
     border-radius: 4px;
-    margin: 0 2px;
+    margin: 0 1px;
+    transition: background 0.1s;
 }
 
 .timeline-cell.scored {
-    background: rgba(255, 255, 255, 0.15);
+    background: rgba(255, 255, 255, 0.12);
+    color: var(--court-cream-dim);
 }
 
 .timeline-cell.empty {
@@ -996,13 +1242,13 @@ h1 {
 }
 
 .timeline-empty {
-    color: rgba(255, 255, 255, 0.4);
+    color: var(--court-cream-off);
     font-style: italic;
-    font-size: 0.9rem;
+    font-size: 0.88rem;
 }
 
+/* ── Controls ────────────────────────────────────────────────────────────── */
 
-/* Controls */
 .controls {
     display: flex;
     gap: 15px;
@@ -1014,34 +1260,46 @@ h1 {
     min-width: 150px;
 }
 
-/* Match Result */
+/* ── Match Result ────────────────────────────────────────────────────────── */
+
 .match-result {
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 15px;
-    padding: 40px;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 16px;
+    padding: 44px 40px;
     backdrop-filter: blur(10px);
+    box-shadow: var(--panel-shadow);
     text-align: center;
 }
 
 .match-result h2 {
-    font-size: 2rem;
-    margin-bottom: 20px;
+    font-family: var(--font-display);
+    font-weight: 400;
+    letter-spacing: 0.1em;
+    font-size: 2.2rem;
+    margin-bottom: 18px;
+    color: var(--court-cream-dim);
 }
 
 .winner {
-    font-size: 2.5rem;
-    font-weight: 700;
-    margin-bottom: 20px;
-    background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+    font-family: var(--font-display);
+    font-weight: 400;
+    font-size: 3.2rem;
+    letter-spacing: 0.08em;
+    margin-bottom: 22px;
+    background: linear-gradient(135deg, #ffe57f 0%, #f5c842 50%, #ff8f00 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
+    text-shadow: none;
+    filter: drop-shadow(0 0 20px rgba(255, 255, 255, 0.3));
 }
 
 .final-score {
     margin-bottom: 30px;
-    font-size: 1.2rem;
-    color: rgba(255, 255, 255, 0.8);
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--court-cream-dim);
 }
 
 .final-score .set-result {
@@ -1053,16 +1311,21 @@ h1 {
     max-width: 300px;
 }
 
-/* Credits Footer */
+/* ── Credits ─────────────────────────────────────────────────────────────── */
+
 .credits {
     position: fixed;
     bottom: 10px;
     right: 15px;
-    font-size: 0.8rem;
-    color: rgba(255, 255, 255, 0.4);
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.3);
+    letter-spacing: 0.04em;
+    z-index: 1;
 }
 
-/* Responsive */
+/* ── Responsive — 768px ──────────────────────────────────────────────────── */
+
 @media (max-width: 768px) {
     .container {
         padding: 10px;
@@ -1070,7 +1333,7 @@ h1 {
     }
 
     h1 {
-        font-size: 1.6rem;
+        font-size: 2.4rem;
         margin-bottom: 20px;
     }
 
@@ -1081,7 +1344,7 @@ h1 {
 
     .team-setup-container {
         flex-direction: column;
-        gap: 15px;
+        gap: 14px;
     }
 
     .team-setup {
@@ -1091,7 +1354,7 @@ h1 {
 
     .team-input input {
         padding: 12px;
-        font-size: 16px; /* Prevents iOS zoom */
+        font-size: 16px; /* prevents iOS zoom */
     }
 
     .rotation-setup-container {
@@ -1104,14 +1367,16 @@ h1 {
     }
 }
 
+/* ── Responsive — 600px ──────────────────────────────────────────────────── */
+
 @media (max-width: 600px) {
     h1 {
-        font-size: 1.4rem;
+        font-size: 2rem;
     }
 
     .current-set {
         flex-direction: column;
-        gap: 15px;
+        gap: 14px;
     }
 
     .team {
@@ -1123,8 +1388,8 @@ h1 {
         flex-direction: row;
         flex-wrap: wrap;
         justify-content: center;
-        gap: 15px;
-        padding: 10px 0;
+        gap: 14px;
+        padding: 8px 0;
     }
 
     .vs {
@@ -1132,18 +1397,18 @@ h1 {
     }
 
     .score {
-        font-size: 3.5rem;
+        font-size: 4.2rem;
     }
 
     .team-name {
-        font-size: 1.1rem;
+        font-size: 1.5rem;
     }
 
     .match-info {
         flex-direction: column;
-        gap: 5px;
+        gap: 4px;
         text-align: center;
-        font-size: 0.85rem;
+        font-size: 0.78rem;
     }
 
     .btn {
@@ -1152,7 +1417,7 @@ h1 {
     }
 
     .btn-score {
-        padding: 16px 20px;
+        padding: 15px 20px;
     }
 
     .rotation-grid {
@@ -1162,7 +1427,7 @@ h1 {
     .rotation-pos {
         width: 36px;
         height: 36px;
-        font-size: 0.8rem;
+        font-size: 0.9rem;
     }
 
     .rotation-row {
@@ -1209,7 +1474,7 @@ h1 {
 
     .serve-indicator {
         width: 70px;
-        height: 36px;
+        height: 34px;
     }
 
     .serve-ball {
@@ -1222,12 +1487,12 @@ h1 {
     }
 
     .set-score-item {
-        font-size: 0.95rem;
-        padding: 4px 12px;
+        font-size: 0.9rem;
+        padding: 3px 11px;
     }
 
     .point-timeline h3 {
-        font-size: 1rem;
+        font-size: 0.78rem;
     }
 
     .timeline-container {
@@ -1235,14 +1500,14 @@ h1 {
     }
 
     .timeline-cell {
-        width: 28px;
-        height: 28px;
+        width: 26px;
+        height: 26px;
         font-size: 0.8rem;
         margin: 0 1px;
     }
 
     .timeline-label {
-        min-width: 20px;
+        min-width: 18px;
     }
 
     .first-serve-icon {
@@ -1271,7 +1536,7 @@ h1 {
     }
 
     .timer-text {
-        font-size: 2.5rem;
+        font-size: 3rem;
     }
 
     .sub-modal-content {
@@ -1285,7 +1550,7 @@ h1 {
     }
 
     .credits {
-        font-size: 0.7rem;
+        font-size: 0.68rem;
         bottom: 5px;
         right: 10px;
     }
@@ -1336,37 +1601,39 @@ h1 {
     }
 }
 
+/* ── Responsive — 360px ──────────────────────────────────────────────────── */
+
 @media (max-width: 360px) {
     h1 {
-        font-size: 1.2rem;
+        font-size: 1.7rem;
     }
 
     .score {
-        font-size: 3rem;
+        font-size: 3.5rem;
     }
 
     .rotation-pos {
         width: 32px;
         height: 32px;
-        font-size: 0.75rem;
+        font-size: 0.8rem;
     }
 
     .timeline-cell {
-        width: 24px;
-        height: 24px;
+        width: 22px;
+        height: 22px;
         font-size: 0.7rem;
     }
 
     .available-player {
-        width: 35px;
-        height: 35px;
-        font-size: 0.8rem;
+        width: 36px;
+        height: 36px;
+        font-size: 0.9rem;
     }
 
     .rotation-setup-pos {
-        width: 42px;
-        height: 42px;
-        font-size: 0.75rem;
+        width: 44px;
+        height: 44px;
+        font-size: 0.9rem;
     }
 
     /* Confirmation modal – small phones (iPhone SE etc.) */
@@ -1397,7 +1664,8 @@ h1 {
     }
 }
 
-/* Landscape mode on mobile */
+/* ── Landscape mobile ────────────────────────────────────────────────────── */
+
 @media (max-height: 500px) and (orientation: landscape) {
     .container {
         padding: 5px 15px;
@@ -1405,8 +1673,9 @@ h1 {
     }
 
     h1 {
-        font-size: 1rem;
+        font-size: 1.4rem;
         margin-bottom: 8px;
+        letter-spacing: 0.06em;
     }
 
     .scoreboard {
@@ -1416,7 +1685,7 @@ h1 {
     .match-info {
         padding: 5px 10px;
         margin-bottom: 10px;
-        font-size: 0.75rem;
+        font-size: 0.72rem;
     }
 
     .current-set {
@@ -1431,18 +1700,18 @@ h1 {
     }
 
     .team-name {
-        font-size: 0.9rem;
+        font-size: 1.2rem;
         margin-bottom: 5px;
     }
 
     .score {
-        font-size: 2rem;
-        margin-bottom: 5px;
+        font-size: 2.6rem;
     }
 
     .btn-score {
         padding: 8px 12px;
-        font-size: 0.8rem;
+        font-size: 0.82rem;
+        margin-top: 8px;
     }
 
     .vs-container {
@@ -1474,7 +1743,7 @@ h1 {
 
     .serve-indicator {
         width: 55px;
-        height: 28px;
+        height: 26px;
     }
 
     .serve-ball {
@@ -1531,7 +1800,7 @@ h1 {
     .rotation-pos {
         width: 26px;
         height: 26px;
-        font-size: 0.65rem;
+        font-size: 0.68rem;
     }
 
     .rotation-pos .sub-indicator {
@@ -1549,7 +1818,7 @@ h1 {
     }
 
     .point-timeline h3 {
-        font-size: 0.8rem;
+        font-size: 0.72rem;
         margin-bottom: 5px;
     }
 
@@ -1558,18 +1827,18 @@ h1 {
     }
 
     .timeline-team {
-        min-height: 24px;
+        min-height: 22px;
     }
 
     .timeline-cell {
         width: 20px;
         height: 20px;
-        font-size: 0.6rem;
+        font-size: 0.62rem;
         margin: 0 1px;
     }
 
     .timeline-label {
-        min-width: 16px;
+        min-width: 14px;
     }
 
     .first-serve-icon {
@@ -1583,7 +1852,7 @@ h1 {
 
     .controls .btn {
         padding: 8px 15px;
-        font-size: 0.8rem;
+        font-size: 0.82rem;
     }
 
     .modal-content {
@@ -1599,17 +1868,17 @@ h1 {
     }
 
     .timer-text {
-        font-size: 1.5rem;
+        font-size: 1.8rem;
     }
 
     .modal-content h2 {
-        font-size: 1rem;
+        font-size: 1.2rem;
         margin-bottom: 10px;
     }
 
     .modal .btn-primary {
         padding: 8px 20px;
-        font-size: 0.85rem;
+        font-size: 0.88rem;
     }
 
     .credits {
@@ -1646,7 +1915,8 @@ h1 {
     }
 }
 
-/* Extra wide landscape (tablets in landscape) */
+/* ── Extra wide landscape (tablets in landscape) ─────────────────────────── */
+
 @media (min-width: 600px) and (max-height: 500px) and (orientation: landscape) {
     .current-set {
         max-width: 900px;
@@ -1658,24 +1928,24 @@ h1 {
     }
 
     .score {
-        font-size: 2.5rem;
+        font-size: 3rem;
     }
 
     .rotation-pos {
         width: 30px;
         height: 30px;
-        font-size: 0.7rem;
+        font-size: 0.72rem;
     }
 }
 
-/* ── New Match Confirmation Modal ─────────────────────────────── */
+/* ── New Match Confirmation Modal ────────────────────────────────────────── */
 
 .confirm-icon {
     width: 52px;
     height: 52px;
     border-radius: 50%;
-    background: rgba(245, 87, 108, 0.12);
-    border: 1px solid rgba(245, 87, 108, 0.28);
+    background: rgba(198, 40, 40, 0.1);
+    border: 1px solid rgba(198, 40, 40, 0.25);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1684,14 +1954,14 @@ h1 {
 }
 
 .confirm-subtitle {
-    color: rgba(255, 255, 255, 0.5);
+    color: var(--court-cream-dim);
     font-size: 0.85rem;
     margin-bottom: 18px;
 }
 
 .confirm-score-summary {
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 12px;
     overflow: hidden;
     margin-bottom: 20px;
@@ -1706,11 +1976,12 @@ h1 {
     background: rgba(255, 255, 255, 0.04);
     border-bottom: 1px solid rgba(255, 255, 255, 0.07);
     font-size: 0.78rem;
-    font-weight: 600;
+    font-weight: 700;
+    letter-spacing: 0.04em;
 }
 
 .confirm-sets-label {
-    color: rgba(255, 255, 255, 0.3);
+    color: var(--court-cream-off);
     font-size: 0.65rem;
     text-transform: uppercase;
     letter-spacing: 0.5px;
@@ -1722,14 +1993,17 @@ h1 {
     align-items: center;
     padding: 10px 14px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-    font-size: 1.3rem;
-    font-weight: 800;
-    color: #fff;
+    font-family: var(--font-display);
+    font-weight: 400;
+    font-size: 1.8rem;
+    letter-spacing: 0.04em;
+    color: var(--court-cream);
 }
 
 .confirm-tally-sep {
-    color: rgba(255, 255, 255, 0.2);
-    font-size: 0.75rem;
+    color: var(--court-cream-off);
+    font-size: 0.9rem;
+    font-family: var(--font-body);
 }
 
 .confirm-set-row {
@@ -1745,12 +2019,12 @@ h1 {
 }
 
 .confirm-set-live {
-    background: rgba(245, 87, 108, 0.05);
+    background: rgba(198, 40, 40, 0.04);
 }
 
 .confirm-set-label {
     font-size: 0.65rem;
-    color: rgba(255, 255, 255, 0.25);
+    color: var(--court-cream-off);
     background: rgba(255, 255, 255, 0.06);
     border: 1px solid transparent;
     border-radius: 4px;
@@ -1758,20 +2032,20 @@ h1 {
 }
 
 .confirm-set-label-live {
-    color: rgba(245, 87, 108, 0.75);
-    background: rgba(245, 87, 108, 0.1);
-    border: 1px solid rgba(245, 87, 108, 0.2);
+    color: rgba(198, 40, 40, 0.75);
+    background: rgba(198, 40, 40, 0.1);
+    border: 1px solid rgba(198, 40, 40, 0.22);
 }
 
 .confirm-score-winner {
     font-size: 0.78rem;
     font-weight: 700;
-    color: rgba(255, 255, 255, 0.9);
+    color: var(--court-cream);
 }
 
 .confirm-score-loser {
     font-size: 0.78rem;
-    color: rgba(255, 255, 255, 0.38);
+    color: var(--court-cream-off);
 }
 
 .confirm-buttons {
@@ -1781,4 +2055,206 @@ h1 {
 
 .confirm-buttons .btn {
     flex: 1;
+}
+
+/* ── Set Lead Charts ─────────────────────────────────────────────────────── */
+
+.final-summary {
+    font-family: var(--font-display);
+    font-size: 1.6rem;
+    letter-spacing: 0.06em;
+    color: var(--court-cream-dim);
+    margin-bottom: 10px;
+}
+
+.set-results-row {
+    margin-bottom: 24px;
+}
+
+.set-charts {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    text-align: left;
+}
+
+.set-chart-wrap {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 10px;
+    padding: 12px 14px 8px;
+}
+
+.set-chart-header {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    margin-bottom: 8px;
+}
+
+.set-chart-label {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--court-cream-off);
+}
+
+.set-chart-score {
+    font-family: var(--font-display);
+    font-size: 1.1rem;
+    letter-spacing: 0.04em;
+    color: var(--court-cream);
+    font-variant-numeric: tabular-nums;
+    flex: 1;
+}
+
+.set-chart-winner {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.set-chart {
+    width: 100%;
+    height: 90px;
+    display: block;
+    overflow: visible;
+}
+
+.lead-line {
+    fill: none;
+    stroke-width: 2.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.set-chart-axis {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.62rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--court-cream-off);
+    margin-top: 4px;
+    padding: 0 4px;
+}
+
+/* ── Match Result Summary ────────────────────────────────────────────────── */
+
+.final-summary {
+    font-family: var(--font-display);
+    font-size: 1.6rem;
+    letter-spacing: 0.06em;
+    color: var(--court-cream);
+    text-align: center;
+    margin-bottom: 6px;
+}
+
+.total-points {
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--court-cream-dim);
+    text-align: center;
+    margin-bottom: 16px;
+}
+
+/* ── Color Picker (Issue #15) ────────────────────────────────────────────── */
+
+.color-picker-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+    flex-wrap: wrap;
+}
+
+.color-picker-row label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--court-cream-dim);
+    text-transform: uppercase;
+    flex-shrink: 0;
+}
+
+.color-picker-row input[type="color"] {
+    width: 32px;
+    height: 32px;
+    border: 2px solid var(--panel-border);
+    border-radius: 6px;
+    padding: 2px;
+    background: transparent;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.color-presets {
+    display: flex;
+    gap: 5px;
+    flex-wrap: wrap;
+}
+
+.color-swatch {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.25);
+    cursor: pointer;
+    padding: 0;
+    transition: transform 0.12s ease, border-color 0.12s ease;
+    flex-shrink: 0;
+}
+
+.color-swatch:hover {
+    transform: scale(1.2);
+    border-color: rgba(255, 255, 255, 0.7);
+}
+
+/* ── Drag & Drop (Issue #17) ─────────────────────────────────────────────── */
+
+.available-player {
+    touch-action: none;
+}
+
+.rotation-setup-pos {
+    touch-action: none;
+}
+
+.drag-ghost {
+    position: fixed;
+    pointer-events: none;
+    z-index: 9999;
+    opacity: 0.85;
+    transform: scale(1.08);
+    transition: none;
+    border-radius: 8px;
+}
+
+.dragging {
+    opacity: 0.4;
+    transform: scale(0.95);
+}
+
+.drop-hint {
+    border-color: var(--court-gold) !important;
+    background: rgba(245, 200, 66, 0.18) !important;
+    box-shadow: 0 0 12px rgba(245, 200, 66, 0.4) !important;
+}
+
+/* ── Animations ──────────────────────────────────────────────────────────── */
+
+@keyframes scorePulse {
+    0%   { transform: scale(1); }
+    40%  { transform: scale(1.08); }
+    75%  { transform: scale(0.97); }
+    100% { transform: scale(1); }
+}
+
+@keyframes modalIn {
+    from { opacity: 0; transform: scale(0.94) translateY(8px); }
+    to   { opacity: 1; transform: scale(1) translateY(0); }
 }


### PR DESCRIPTION
Closes #5, Closes #6, Closes #11, Closes #15, Closes #16, Closes #17

## Summary

- **Drag-and-drop rotation assignment** using the Pointer Events API; click-to-assign (select slot → click jersey) coexists alongside it
- **Fix: Start Match required two clicks after a drag** — capture-phase click suppression scoped too broadly; now only suppresses clicks on draggable/droppable elements
- **Fix: empty rotation slot placeholders were draggable** — added early-return guard in `pointerdown` when slot is empty
- **"Use previous rotation" button** per team — hidden on set 1, shown from set 2 onward; clears any pending slot selection when applied
- **Customizable team colors** via color picker with preset swatches, persisted in `localStorage`
- **Remove redundant "New Match" button** from scoreboard (identical to "Return to Setup")
- **Fix: chart X-axis labels could exceed 25** — switched from rally-count ticks to score-milestone ticks capped at `maxScore`
- **Fix: swapTeams() undo history** — all `pointHistory` snapshots (including `points` arrays inside `setHistory`) are remapped instead of cleared, so undo works correctly across swaps
- **Fix: XSS** — `escapeHtml()` applied at all team-name `innerHTML` injection sites, including the rotation setup error div
- **Fix: `hexToRgb()`** handles 3-digit hex colors
- **Fix: jersey length cap** corrected to 3 characters
- **Fix: DnD listener accumulation** across set breaks via `_dndInitialized` guard
- **Fix: `confirmReturnToSetup()` side effect** that was triggering `showNewSetRotationSetup` prematurely
- **Remove dead `isValidInteger()` function**
- **Update CLAUDE.md**: modal list (2→4), `switchSides`/`swapTeams` descriptions, set break flow, "use previous rotation" feature docs
- **Rewrite README.md** for v3.0 feature set; add CLAUDE.md to repo

## Test plan

- [ ] Rotation setup: drag a jersey into a slot, then click Start Match — should start on the **first** click
- [ ] Rotation setup: attempt to drag an empty slot — no ghost, no state change; clicking the slot still selects it
- [ ] Rotation setup: click-to-assign (select slot → click jersey) still works alongside drag-and-drop
- [ ] Rotation setup: select a slot (yellow ring), then click "Use previous rotation" — ring clears and slots fill correctly
- [ ] Set 2+ rotation screen: "Use previous rotation" buttons appear for both teams and fill the correct rotation
- [ ] Set 1 rotation screen: "Use previous rotation" buttons are hidden
- [ ] Scoreboard: no "New Match" button visible; "Return to Setup" still present
- [ ] Match result chart: play a 25-20 set; X-axis labels show exactly 5, 10, 15, 20, 25
- [ ] Swap teams mid-match, score a point, undo — scores and rotations revert correctly
- [ ] Color picker: set custom colors in setup, verify they persist after page reload
- [ ] "Use previous rotation" button has visible gap below the jersey palette (does not graze numbers on hover)