### PR TITLE
Add PWA support: installable, offline-capable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,13 @@ Deployment is automated via GitHub Actions (`.github/workflows/deploy.yml`) — 
 
 ## Architecture
 
-The app is a single-page vanilla JS application with three files:
+The app is a single-page vanilla JS application with three source files plus PWA support files:
 
 - `index.html` — all markup; four screens toggled via the `hidden` CSS class
 - `styles.css` — all styling; uses CSS variables and flexbox
 - `app.js` — all logic; single file, no modules
+- `manifest.webmanifest` — installability metadata; relative `start_url`/`scope` resolve correctly under the `/VolleyballReferee/` GitHub Pages subpath
+- `sw.js` — service worker (see PWA / offline section below)
 
 ### Screen flow
 
@@ -69,3 +71,9 @@ When a set ends, `checkSetWin()` calls `showSetBreakModal(nextSetNumber)` which 
 ### "Use previous rotation" feature
 
 `state.lastStartingRotation1` and `state.lastStartingRotation2` store the flat 6-element rotation arrays from the most recently confirmed starting rotation for each team. They are written in `confirmRotationSetup()` after building `state.team1Rotation`/`team2Rotation`, and nulled in `resetMatchState()`. Both fields are included in the `beginMatch()` save/restore block so they survive the `resetMatchState()` call. The `.use-prev-rotation[data-team="1/2"]` buttons are hidden (via `updatePrevRotationButtons()`) when the corresponding field is null (set 1), and shown from set 2 onward.
+
+### PWA / offline
+
+`manifest.webmanifest` — installability metadata; relative `start_url`/`scope` (`"./"`) resolve correctly under the `/VolleyballReferee/` GitHub Pages subpath and also work for local server testing.
+
+`sw.js` — service worker. Cache name is `vbref-v${VERSION}`; **bump `VERSION` in `sw.js` to invalidate all clients on the next deploy** and force re-download of updated assets. `APP_SHELL` lists every file precached at install — **add new CSS, JS, or icon files here or they will not be available offline**. HTML navigations use network-first (fresh on online reload, cached fallback offline). All other same-origin assets use cache-first. Cross-origin requests (Google Fonts, Analytics) are not intercepted and not cached — they silently fail offline, which is acceptable.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The app is fully responsive and optimized for:
 
 ## Version History
 
+- **v3.01** - PWA support: installable to home screen, full offline capability via service worker
 - **v3.0** - Drag-and-drop rotation assignment; customizable team colors; letter/emoji jerseys; lead-margin charts; total points; return-to-setup mid-match; "use previous rotation" button; polished indoor arena theme
 - **v2.01** - Optimized landscape mode for mobile phones, reduced scrolling
 - **v1.7** - Added live demo link and GitHub Actions deployment

--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
         </div>
     </div>
 
-    <footer class="credits">v3.0 | Created by Menon Pranto</footer>
+    <footer class="credits">v3.01 | Created by Menon Pranto</footer>
 
     <script src="app.js"></script>
     <script>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Barlow+Semi+Condensed:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
+    <link rel="manifest" href="./manifest.webmanifest">
+    <meta name="description" content="Volleyball scoresheet for tracking matches, rotations, substitutions, and more.">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-RBPL9H3D0Y"></script>
     <script>
@@ -314,5 +316,12 @@
     <footer class="credits">v3.0 | Created by Menon Pranto</footer>
 
     <script src="app.js"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('./sw.js').catch(() => {});
+        });
+      }
+    </script>
 </body>
 </html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "Volleyball Referee",
+  "short_name": "VB Ref",
+  "description": "Volleyball scoresheet for tracking matches, rotations, substitutions, and more.",
+  "start_url": "./",
+  "scope": "./",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#071545",
+  "theme_color": "#071545",
+  "icons": [
+    { "src": "icons/volleyball.png", "sizes": "192x192", "type": "image/png", "purpose": "any" },
+    { "src": "icons/volleyball.png", "sizes": "512x512", "type": "image/png", "purpose": "any" }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,60 @@
+const VERSION = 'v3.0.0';
+const CACHE = `vbref-${VERSION}`;
+// Add every new app-shell asset here or it will not be available offline.
+const APP_SHELL = [
+  './',
+  './index.html',
+  './styles.css',
+  './app.js',
+  './manifest.webmanifest',
+  './icons/volleyball.png',
+  './icons/swap.png',
+  './icons/timer.png',
+  './icons/undo.png'
+];
+
+self.addEventListener('install', e => {
+  e.waitUntil(caches.open(CACHE).then(c => c.addAll(APP_SHELL)).then(() => self.skipWaiting()));
+});
+
+self.addEventListener('activate', e => {
+  e.waitUntil(
+    caches.keys()
+      .then(keys => Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', e => {
+  const req = e.request;
+  if (req.method !== 'GET') return;
+  const url = new URL(req.url);
+
+  // Skip cross-origin requests (Google Fonts, Analytics) — let the network handle them.
+  if (url.origin !== self.location.origin) return;
+
+  // Network-first for HTML navigations so updates ship immediately when online.
+  if (req.mode === 'navigate' || req.headers.get('accept')?.includes('text/html')) {
+    e.respondWith(
+      fetch(req).then(res => {
+        if (res.ok) {
+          const copy = res.clone();
+          caches.open(CACHE).then(c => c.put(req, copy));
+        }
+        return res;
+      }).catch(() => caches.match(req).then(r => r || caches.match('./index.html')))
+    );
+    return;
+  }
+
+  // Cache-first for everything else (CSS, JS, icons).
+  e.respondWith(
+    caches.match(req).then(cached => cached || fetch(req).then(res => {
+      if (res.ok) {
+        const copy = res.clone();
+        caches.open(CACHE).then(c => c.put(req, copy));
+      }
+      return res;
+    }))
+  );
+});


### PR DESCRIPTION
## Summary

- Add `manifest.webmanifest` — app name, short name, icons (512×512 volleyball PNG), `standalone` display, `theme_color`/`background_color` matching the arena-blue design system (`#071545`). Relative `start_url`/`scope` work correctly under the `/VolleyballReferee/` GitHub Pages subpath.
- Add `sw.js` — service worker with precached app shell (all HTML, CSS, JS, and icons). Network-first for HTML navigations so deploys ship immediately when online; cache-first for static assets. Cross-origin requests (Google Fonts, Analytics) are not intercepted. Bump `VERSION` in `sw.js` to invalidate the cache on the next deploy.
- Update `index.html` — add `<link rel="manifest">`, description meta tag, and SW registration script (deferred to `load`, gated on `'serviceWorker' in navigator`).
- Update `CLAUDE.md` — add PWA/offline architecture section documenting the cache strategy, `APP_SHELL` list, and cache versioning pattern.

## Test plan

- [ ] Chrome DevTools → Application → Manifest: name, icons, start_url, scope, theme_color all present with no errors
- [ ] Application → Service Workers: `sw.js` shows "activated and running"
- [ ] Tick "Offline" in DevTools, reload — app loads and is fully usable (set up a match, score points)
- [ ] Cache Storage → `vbref-v3.0.0`: all 9 shell assets present
- [ ] Chrome desktop: install icon appears in address bar → install → launches as standalone window
- [ ] iOS Safari: Share → Add to Home Screen → opens fullscreen with correct status bar color