### PR TITLE
Add match-state persistence via localStorage (v3.02)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,3 +77,7 @@ When a set ends, `checkSetWin()` calls `showSetBreakModal(nextSetNumber)` which 
 `manifest.webmanifest` — installability metadata; relative `start_url`/`scope` (`"./"`) resolve correctly under the `/VolleyballReferee/` GitHub Pages subpath and also work for local server testing.
 
 `sw.js` — service worker. Cache name is `vbref-v${VERSION}`; **bump `VERSION` in `sw.js` to invalidate all clients on the next deploy** and force re-download of updated assets. `APP_SHELL` lists every file precached at install — **add new CSS, JS, or icon files here or they will not be available offline**. HTML navigations use network-first (fresh on online reload, cached fallback offline). All other same-origin assets use cache-first. Cross-origin requests (Google Fonts, Analytics) are not intercepted and not cached — they silently fail offline, which is acceptable.
+
+### Match state persistence
+
+The full `state` object is serialized to localStorage under the key `vb-match-state` after every `updateDisplay()` call. On `init()`, `restoreSavedMatch()` reads it and routes the user back to the correct screen (scoreboard / rotation setup / match result). Stored under a `_schema` version field — bump `STORAGE_SCHEMA` when the state shape changes in a way that breaks restore, and stale data is silently dropped. `resetMatchState()` clears the stored state so a "Return to Setup" reliably starts fresh. Timer intervals (timeout countdown, set break) live in module-level vars, not in state — they are NOT restored, so a timeout interrupted by reload simply ends.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The app is fully responsive and optimized for:
 
 ## Version History
 
+- **v3.02** - Match state survives app close/reload (full scoresheet retention via localStorage)
 - **v3.01** - PWA support: installable to home screen, full offline capability via service worker
 - **v3.0** - Drag-and-drop rotation assignment; customizable team colors; letter/emoji jerseys; lead-margin charts; total points; return-to-setup mid-match; "use previous rotation" button; polished indoor arena theme
 - **v2.01** - Optimized landscape mode for mobile phones, reduced scrolling

--- a/app.js
+++ b/app.js
@@ -32,7 +32,8 @@ const state = {
     team1OriginalId: 'A',
     team2OriginalId: 'B',
     lastStartingRotation1: null,
-    lastStartingRotation2: null
+    lastStartingRotation2: null,
+    matchStarted: false
 };
 
 const rotationSetupState = {
@@ -55,6 +56,30 @@ let timeoutInterval = null;
 let setBreakInterval = null;
 let _scorePulseTeam = null;
 let _dndInitialized = false;
+
+const STORAGE_KEY = 'vb-match-state';
+const STORAGE_SCHEMA = 1;
+
+function saveState() {
+    try {
+        const payload = { _schema: STORAGE_SCHEMA, state };
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    } catch (_) {}
+}
+
+function loadState() {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        if (parsed?._schema !== STORAGE_SCHEMA) { clearState(); return null; }
+        return parsed.state || null;
+    } catch (_) { return null; }
+}
+
+function clearState() {
+    try { localStorage.removeItem(STORAGE_KEY); } catch (_) {}
+}
 
 function initDragAndDrop() {
     if (_dndInitialized) return;
@@ -227,6 +252,41 @@ function applyTeamColors(c1, c2) {
     try { localStorage.setItem('vb-team-colors', JSON.stringify({ c1, c2 })); } catch (_) {}
 }
 
+function restoreSavedMatch() {
+    const saved = loadState();
+    if (!saved) return false;
+
+    Object.assign(state, saved);
+
+    // matchStarted covers no-jersey matches; team1Players.length covers old saves from jersey matches
+    const inProgress = state.matchStarted || state.team1Players.length > 0;
+
+    if (state.matchOver) {
+        endMatch();
+    } else if (!inProgress) {
+        return false;
+    } else if (state.hasRotation && state.team1Rotation.length === 6) {
+        document.getElementById('setup').classList.add('hidden');
+        document.getElementById('rotationSetup').classList.add('hidden');
+        document.getElementById('scoreboard').classList.remove('hidden');
+        document.getElementById('matchResult').classList.add('hidden');
+        document.getElementById('rotation1').classList.remove('hidden');
+        document.getElementById('rotation2').classList.remove('hidden');
+        updateDisplay();
+    } else if (state.hasRotation) {
+        showNewSetRotationSetup();
+    } else {
+        document.getElementById('setup').classList.add('hidden');
+        document.getElementById('rotationSetup').classList.add('hidden');
+        document.getElementById('scoreboard').classList.remove('hidden');
+        document.getElementById('matchResult').classList.add('hidden');
+        document.getElementById('rotation1').classList.add('hidden');
+        document.getElementById('rotation2').classList.add('hidden');
+        updateDisplay();
+    }
+    return true;
+}
+
 function init() {
     // Restore saved team colors
     try {
@@ -302,6 +362,8 @@ function init() {
             document.querySelectorAll('.rotation-setup-pos').forEach(p => p.classList.remove('selected'));
         });
     });
+
+    restoreSavedMatch();
 }
 
 function toggleService() {
@@ -906,6 +968,9 @@ function showRotationSetup() {
 }
 
 function showNewSetRotationSetup() {
+    state.team1Rotation = [];
+    state.team2Rotation = [];
+    saveState();
     document.getElementById('scoreboard').classList.add('hidden');
     document.getElementById('rotationSetup').classList.remove('hidden');
 
@@ -1093,6 +1158,7 @@ function beginMatch() {
     const savedLast1 = state.lastStartingRotation1;
     const savedLast2 = state.lastStartingRotation2;
     resetMatchState();
+    state.matchStarted = true;
     state.team1Rotation = savedR1;
     state.team2Rotation = savedR2;
     state.hasRotation = savedHasRotation;
@@ -1116,6 +1182,7 @@ function beginMatch() {
 }
 
 function resetMatchState() {
+    clearState();
     state.currentSet = 1;
     state.team1Score = 0;
     state.team2Score = 0;
@@ -1140,6 +1207,7 @@ function resetMatchState() {
     state.hasRotation = false;
     state.lastStartingRotation1 = null;
     state.lastStartingRotation2 = null;
+    state.matchStarted = false;
 }
 
 function resetToSetup() {
@@ -1556,6 +1624,7 @@ function updateDisplay() {
 
     const container = document.querySelector('.timeline-container');
     container.scrollLeft = container.scrollWidth;
+    saveState();
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
         </div>
     </div>
 
-    <footer class="credits">v3.01 | Created by Menon Pranto</footer>
+    <footer class="credits">v3.02 | Created by Menon Pranto</footer>
 
     <script src="app.js"></script>
     <script>

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const VERSION = 'v3.0.0';
+const VERSION = 'v3.0.2';
 const CACHE = `vbref-${VERSION}`;
 // Add every new app-shell asset here or it will not be available offline.
 const APP_SHELL = [


### PR DESCRIPTION
## Summary

- Full scoresheet survives app close, reload, or OS kill — scores, rotations, substitutions, and undo history all restore automatically on next open
- Works for both jersey and no-jersey matches across 3-set and 5-set formats
- Schema-versioned (`STORAGE_SCHEMA = 1`) so stale or incompatible saved data is silently dropped and the user lands on the setup screen instead of a corrupted state
- `sw.js` VERSION bumped to `v3.0.2` so PWA-installed users receive updated assets on next deploy
- Closes #33 follow-up work deferred (resume confirmation modal)

## How it works

- `saveState()` is called at the end of every `updateDisplay()` — covers all 9 mutation paths with a single hook
- `restoreSavedMatch()` runs at the end of `init()` and routes back to the correct screen: match result, scoreboard (with or without rotation panels), or between-sets rotation setup
- `resetMatchState()` clears localStorage so "Return to Setup" always starts fresh
- Timer intervals (timeout countdown, set break) are not persisted — an interrupted countdown simply ends on reload

## Test plan

- [ ] Start a no-jersey match, score points, refresh — should land back on scoreboard at same score
- [ ] Start a jersey match, confirm rotation, score points, refresh — scoreboard with rotation intact
- [ ] Reload between sets (rotation setup visible) — should land back on rotation setup
- [ ] Complete a match, reload — should land on match result screen with full chart
- [ ] Click "Return to Setup", confirm — `vb-match-state` removed from localStorage; reload lands on setup
- [ ] Test both 3-set and 5-set formats for each of the above
- [ ] DevTools → Application → Storage: confirm `vb-match-state` size is well under 1 MB after a long match