### PR TITLE
Add match history, schema migration, rotation-setup persistence, serve indicator fix (v3.03)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The app is fully responsive and optimized for:
 
 ## Version History
 
+- **v3.03** - Schema migration framework for future localStorage upgrades; rotation-setup state persisted across reloads; match history log with per-set score pills
 - **v3.02** - Match state survives app close/reload (full scoresheet retention via localStorage)
 - **v3.01** - PWA support: installable to home screen, full offline capability via service worker
 - **v3.0** - Drag-and-drop rotation assignment; customizable team colors; letter/emoji jerseys; lead-margin charts; total points; return-to-setup mid-match; "use previous rotation" button; polished indoor arena theme

--- a/app.js
+++ b/app.js
@@ -56,29 +56,62 @@ let timeoutInterval = null;
 let setBreakInterval = null;
 let _scorePulseTeam = null;
 let _dndInitialized = false;
+let _restoredRotationSetup = null;
 
 const STORAGE_KEY = 'vb-match-state';
 const STORAGE_SCHEMA = 1;
+const HISTORY_KEY = 'vb-match-history';
+const HISTORY_MAX = 50;
 
 function saveState() {
     try {
-        const payload = { _schema: STORAGE_SCHEMA, state };
+        const payload = { _schema: STORAGE_SCHEMA, state, rotationSetup: { ...rotationSetupState } };
         localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
     } catch (_) {}
+}
+
+// Extension point for schema upgrades. Add a case per version step.
+// Each call must advance _schema by exactly one step (fromVersion → fromVersion+1).
+// Return the upgraded payload { _schema, state, rotationSetup } or null to discard.
+function migrate(saved, fromVersion) {
+    // no migrations defined yet
+    return null;
 }
 
 function loadState() {
     try {
         const raw = localStorage.getItem(STORAGE_KEY);
         if (!raw) return null;
-        const parsed = JSON.parse(raw);
-        if (parsed?._schema !== STORAGE_SCHEMA) { clearState(); return null; }
-        return parsed.state || null;
+        let cur = JSON.parse(raw);
+        while (cur?._schema !== STORAGE_SCHEMA) {
+            const next = migrate(cur, cur?._schema);
+            if (!next || next._schema === cur._schema) { clearState(); return null; }
+            cur = next;
+        }
+        return { state: cur.state || null, rotationSetup: cur.rotationSetup || null };
     } catch (_) { return null; }
 }
 
 function clearState() {
     try { localStorage.removeItem(STORAGE_KEY); } catch (_) {}
+}
+
+function saveMatchToHistory(matchData) {
+    try {
+        const history = loadMatchHistory();
+        history.unshift(matchData);
+        if (history.length > HISTORY_MAX) history.length = HISTORY_MAX;
+        localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+    } catch (_) {}
+}
+
+function loadMatchHistory() {
+    try {
+        const raw = localStorage.getItem(HISTORY_KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : [];
+    } catch (_) { return []; }
 }
 
 function initDragAndDrop() {
@@ -206,6 +239,7 @@ function initDragAndDrop() {
                         setPlayer(dragTeam, dragFromPos, displaced);
                     }
                     refreshUI(dragTeam);
+                    saveState();
                 }
             }
         }
@@ -253,8 +287,9 @@ function applyTeamColors(c1, c2) {
 }
 
 function restoreSavedMatch() {
-    const saved = loadState();
-    if (!saved) return false;
+    const loaded = loadState();
+    if (!loaded) return false;
+    const { state: saved, rotationSetup: savedRS } = loaded;
 
     Object.assign(state, saved);
 
@@ -265,6 +300,11 @@ function restoreSavedMatch() {
         endMatch();
     } else if (!inProgress) {
         return false;
+    } else if (state.team1Players.length > 0 && state.hasRotation && (!Array.isArray(state.team1Rotation) || state.team1Rotation.length === 0) && !state.matchStarted) {
+        // reloaded mid-first-set rotation setup
+        _restoredRotationSetup = savedRS || null;
+        showRotationSetup();
+        return true;
     } else if (state.hasRotation && state.team1Rotation.length === 6) {
         document.getElementById('setup').classList.add('hidden');
         document.getElementById('rotationSetup').classList.add('hidden');
@@ -274,6 +314,7 @@ function restoreSavedMatch() {
         document.getElementById('rotation2').classList.remove('hidden');
         updateDisplay();
     } else if (state.hasRotation) {
+        _restoredRotationSetup = savedRS || null;
         showNewSetRotationSetup();
     } else {
         document.getElementById('setup').classList.add('hidden');
@@ -319,6 +360,12 @@ function init() {
     document.getElementById('startMatch').addEventListener('click', startMatch);
     document.getElementById('playAgain').addEventListener('click', resetToSetup);
     document.getElementById('undoPoint').addEventListener('click', undoLastPoint);
+    document.getElementById('historyBtn').addEventListener('click', showHistoryModal);
+    document.getElementById('closeHistory').addEventListener('click', closeHistoryModal);
+    document.getElementById('historyModal').addEventListener('click', e => {
+        if (e.target === document.getElementById('historyModal')) closeHistoryModal();
+    });
+    updateHistoryButton();
 
     document.querySelectorAll('.btn-score').forEach(btn => {
         btn.addEventListener('click', (e) => {
@@ -360,6 +407,7 @@ function init() {
             rotationSetupState.selectedPosition = null;
             rotationSetupState.selectedTeam = null;
             document.querySelectorAll('.rotation-setup-pos').forEach(p => p.classList.remove('selected'));
+            saveState();
         });
     });
 
@@ -704,6 +752,52 @@ function closeSubModal() {
     currentSubPosition = null;
 }
 
+function showHistoryModal() {
+    const history = loadMatchHistory();
+    const listEl = document.getElementById('historyList');
+
+    if (history.length === 0) {
+        listEl.innerHTML = '<p class="history-empty">No completed matches yet.</p>';
+    } else {
+        listEl.innerHTML = history.map(entry => {
+            const date = new Date(entry.finishedAt);
+            const dateStr = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+            const timeStr = date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+            const setsHTML = (entry.setHistory || []).map(s => {
+                const wc = s.winner === 1 ? (entry.team1Color || '#4a9eff') : (entry.team2Color || '#f5a623');
+                const wr = s.winner === 1 ? (entry.team1Rgb || '74,158,255') : (entry.team2Rgb || '245,166,35');
+                const ps = `background:rgba(${wr},0.18);color:${wc};border:1px solid rgba(${wr},0.3);`;
+                return `<span class="history-set-score" style="${ps}">${s.team1Score}–${s.team2Score}</span>`;
+            }).join('');
+            return `
+                <div class="history-entry">
+                    <div class="history-entry-header">
+                        <span class="history-winner">${escapeHtml(entry.winner)}</span>
+                        <span class="history-date">${dateStr} · ${timeStr}</span>
+                    </div>
+                    <div class="history-teams">
+                        <span class="history-team-name">${escapeHtml(entry.team1Name)}</span>
+                        <span class="history-sets-tally">${entry.team1Sets} – ${entry.team2Sets}</span>
+                        <span class="history-team-name">${escapeHtml(entry.team2Name)}</span>
+                    </div>
+                    <div class="history-set-scores">${setsHTML}</div>
+                </div>`;
+        }).join('');
+    }
+
+    document.getElementById('historyModal').classList.remove('hidden');
+}
+
+function closeHistoryModal() {
+    document.getElementById('historyModal').classList.add('hidden');
+}
+
+function updateHistoryButton() {
+    const btn = document.getElementById('historyBtn');
+    if (!btn) return;
+    btn.style.display = loadMatchHistory().length > 0 ? '' : 'none';
+}
+
 function checkLiberoFrontRow(team) {
     const libero = team === 1 ? state.team1Libero : state.team2Libero;
     const rotation = team === 1 ? state.team1Rotation : state.team2Rotation;
@@ -863,6 +957,7 @@ function startMatch() {
 
     if (team1Players.length >= 6 && team2Players.length >= 6) {
         state.hasRotation = true;
+        saveState();
         showRotationSetup();
     } else {
         state.hasRotation = false;
@@ -954,6 +1049,14 @@ function showRotationSetup() {
     rotationSetupState.selectedTeam = null;
     rotationSetupState.isNewSet = false;
 
+    if (_restoredRotationSetup && !_restoredRotationSetup.isNewSet) {
+        Object.assign(rotationSetupState, _restoredRotationSetup);
+        rotationSetupState.selectedPosition = null;
+        rotationSetupState.selectedTeam = null;
+        _restoredRotationSetup = null;
+    }
+    saveState();
+
     updateAvailablePlayers(1);
     updateAvailablePlayers(2);
     updateRotationSetupDisplay();
@@ -982,6 +1085,14 @@ function showNewSetRotationSetup() {
     rotationSetupState.selectedPosition = null;
     rotationSetupState.selectedTeam = null;
     rotationSetupState.isNewSet = true;
+
+    if (_restoredRotationSetup && _restoredRotationSetup.isNewSet) {
+        Object.assign(rotationSetupState, _restoredRotationSetup);
+        rotationSetupState.selectedPosition = null;
+        rotationSetupState.selectedTeam = null;
+        _restoredRotationSetup = null;
+    }
+    saveState();
 
     updateAvailablePlayers(1);
     updateAvailablePlayers(2);
@@ -1047,12 +1158,14 @@ function handlePositionClick(e) {
         rotationSetupState.selectedTeam = null;
         updateAvailablePlayers(team);
         updateRotationSetupDisplay();
+        saveState();
         return;
     }
 
     e.target.classList.add('selected');
     rotationSetupState.selectedPosition = pos;
     rotationSetupState.selectedTeam = team;
+    saveState();
 }
 
 function handlePlayerSelect(e) {
@@ -1072,6 +1185,7 @@ function handlePlayerSelect(e) {
     document.querySelectorAll('.rotation-setup-pos').forEach(p => p.classList.remove('selected'));
     updateAvailablePlayers(team);
     updateRotationSetupDisplay();
+    saveState();
 }
 
 function updateRotationSetupDisplay() {
@@ -1136,6 +1250,9 @@ function confirmRotationSetup() {
 
     state.lastStartingRotation1 = [...state.team1Rotation];
     state.lastStartingRotation2 = [...state.team2Rotation];
+
+    rotationSetupState.team1Rotation = { 1: null, 2: null, 3: null, 4: null, 5: null, 6: null };
+    rotationSetupState.team2Rotation = { 1: null, 2: null, 3: null, 4: null, 5: null, 6: null };
 
     document.getElementById('rotationSetup').classList.add('hidden');
     
@@ -1208,6 +1325,7 @@ function resetMatchState() {
     state.lastStartingRotation1 = null;
     state.lastStartingRotation2 = null;
     state.matchStarted = false;
+    _restoredRotationSetup = null;
 }
 
 function resetToSetup() {
@@ -1305,6 +1423,25 @@ function checkSetWin() {
         }
 
         if (state.team1Sets >= state.setsToWin || state.team2Sets >= state.setsToWin) {
+            const _cs = getComputedStyle(document.documentElement);
+            const _colorA = _cs.getPropertyValue('--team1-color').trim();
+            const _colorB = _cs.getPropertyValue('--team2-color').trim();
+            const _rgbA   = _cs.getPropertyValue('--team1-rgb').trim();
+            const _rgbB   = _cs.getPropertyValue('--team2-rgb').trim();
+            saveMatchToHistory({
+                finishedAt: Date.now(),
+                team1Name: state.team1Name,
+                team2Name: state.team2Name,
+                team1Sets: state.team1Sets,
+                team2Sets: state.team2Sets,
+                winner: state.team1Sets > state.team2Sets ? state.team1Name : state.team2Name,
+                team1Color: state.team1OriginalId === 'A' ? _colorA : _colorB,
+                team2Color: state.team2OriginalId === 'A' ? _colorA : _colorB,
+                team1Rgb:   state.team1OriginalId === 'A' ? _rgbA   : _rgbB,
+                team2Rgb:   state.team2OriginalId === 'A' ? _rgbA   : _rgbB,
+                setHistory: state.setHistory.map(s => ({ team1Score: s.team1Score, team2Score: s.team2Score, winner: s.winner }))
+            });
+            updateHistoryButton();
             endMatch();
         } else {
             state.currentSet++;

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
     </script>
 </head>
 <body>
+    <button id="historyBtn" class="history-btn" style="display:none">History</button>
     <div class="container">
         <h1>Volleyball Referee</h1>
 
@@ -313,7 +314,15 @@
         </div>
     </div>
 
-    <footer class="credits">v3.02 | Created by Menon Pranto</footer>
+    <div id="historyModal" class="modal hidden">
+        <div class="modal-content history-modal-content">
+            <h2>Match History</h2>
+            <div id="historyList" class="history-list"></div>
+            <button class="btn btn-secondary" id="closeHistory">Close</button>
+        </div>
+    </div>
+
+    <footer class="credits">v3.03 | Created by Menon Pranto</footer>
 
     <script src="app.js"></script>
     <script>

--- a/styles.css
+++ b/styles.css
@@ -1486,6 +1486,10 @@ h1 {
         height: 26px;
     }
 
+    .serve-ball.right {
+        left: calc(100% - 30px);
+    }
+
     .sets-score-center {
         gap: 4px;
     }
@@ -1753,6 +1757,10 @@ h1 {
     .serve-ball {
         width: 20px;
         height: 20px;
+    }
+
+    .serve-ball.right {
+        left: calc(100% - 24px);
     }
 
     .sets-score-center {
@@ -2261,4 +2269,164 @@ h1 {
 @keyframes modalIn {
     from { opacity: 0; transform: scale(0.94) translateY(8px); }
     to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+/* ── History Button ──────────────────────────────────────────────────────── */
+
+.history-btn {
+    position: fixed;
+    top: max(14px, env(safe-area-inset-top, 0px));
+    right: max(14px, env(safe-area-inset-right, 0px));
+    z-index: 500;
+    padding: 8px 16px;
+    font-family: var(--font-body);
+    font-weight: 600;
+    font-size: 0.8rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--court-gold);
+    background: rgba(245, 200, 66, 0.1);
+    border: 1px solid rgba(245, 200, 66, 0.35);
+    border-radius: 20px;
+    cursor: pointer;
+    transition: background 0.18s, border-color 0.18s, transform 0.12s;
+}
+
+.history-btn:hover {
+    background: rgba(245, 200, 66, 0.2);
+    border-color: rgba(245, 200, 66, 0.6);
+    transform: translateY(-1px);
+}
+
+.history-btn:active {
+    transform: translateY(0);
+}
+
+/* ── History Modal ───────────────────────────────────────────────────────── */
+
+.history-modal-content {
+    text-align: left;
+    max-width: 520px;
+    width: 100%;
+    padding: 36px 36px 28px;
+}
+
+.history-modal-content h2 {
+    text-align: center;
+}
+
+.history-list {
+    max-height: 60vh;
+    overflow-y: auto;
+    margin-bottom: 24px;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(245, 200, 66, 0.3) transparent;
+}
+
+.history-list::-webkit-scrollbar { width: 4px; }
+.history-list::-webkit-scrollbar-track { background: transparent; }
+.history-list::-webkit-scrollbar-thumb {
+    background: rgba(245, 200, 66, 0.3);
+    border-radius: 2px;
+}
+
+.history-empty {
+    text-align: center;
+    color: var(--court-cream-off);
+    font-size: 0.95rem;
+    padding: 20px 0;
+}
+
+.history-entry {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+    padding: 14px 16px;
+    margin-bottom: 10px;
+    transition: background 0.15s;
+}
+
+.history-entry:last-child { margin-bottom: 0; }
+.history-entry:hover { background: rgba(255, 255, 255, 0.07); }
+
+.history-entry-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 8px;
+}
+
+.history-winner {
+    font-family: var(--font-display);
+    font-weight: 400;
+    font-size: 1.1rem;
+    letter-spacing: 0.06em;
+    color: var(--court-gold);
+}
+
+.history-date {
+    font-size: 0.72rem;
+    color: var(--court-cream-off);
+    letter-spacing: 0.02em;
+}
+
+.history-teams {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 8px;
+}
+
+.history-team-name {
+    flex: 1;
+    font-weight: 600;
+    font-size: 0.92rem;
+    color: var(--court-cream-dim);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.history-team-name:last-child { text-align: right; }
+
+.history-sets-tally {
+    font-family: var(--font-display);
+    font-size: 1.4rem;
+    letter-spacing: 0.06em;
+    color: var(--court-cream);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.history-set-scores {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.history-set-score {
+    font-size: 0.78rem;
+    font-weight: 600;
+    padding: 3px 10px;
+    border-radius: 10px;
+    letter-spacing: 0.02em;
+}
+
+.hist-team1-win {
+    background: rgba(var(--team1-rgb), 0.18);
+    color: var(--team1-color);
+    border: 1px solid rgba(var(--team1-rgb), 0.3);
+}
+
+.hist-team2-win {
+    background: rgba(var(--team2-rgb), 0.18);
+    color: var(--team2-color);
+    border: 1px solid rgba(var(--team2-rgb), 0.3);
+}
+
+.history-modal-content .btn-secondary {
+    display: block;
+    margin: 0 auto;
+    min-width: 120px;
 }

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const VERSION = 'v3.0.2';
+const VERSION = 'v3.0.3';
 const CACHE = `vbref-${VERSION}`;
 // Add every new app-shell asset here or it will not be available offline.
 const APP_SHELL = [


### PR DESCRIPTION
## Summary

- **Match history log** — completed matches saved to `vb-match-history` localStorage key (50-entry cap); modal accessible via a History button that appears once any match has been recorded; per-set score pills displayed in the winning team's color, snapshotted at match-end using `originalId` identity mapping so colors remain correct after team swaps
- **Schema migration ladder** — `loadState()` now runs a while-loop calling `migrate()` until the payload reaches the current schema version; safe to discard on failure; extension point ready for future state shape changes (closes #34)
- **Rotation-setup state persistence** — `rotationSetupState` serialized into every `saveState()` call; restored via a `_restoredRotationSetup` cache consumed only inside the two rotation-setup routing branches; `selectedPosition`/`selectedTeam` cleared after restore to avoid a stale highlighted position on reload (closes #35)
- **Serve indicator symmetry fix** — `.serve-ball.right` position overrides added for the 26 px (portrait ≤600 px) and 20 px (landscape) breakpoints so the ball sits with a 4 px gap on both sides at every screen size

## Test plan

- [ ] Start a match, partially fill rotation setup, reload — assignments should be restored; no position should appear pre-selected
- [ ] Complete a match; History button appears; pills show each set winner's color
- [ ] Swap teams mid-match, complete — history pills still use the correct team's color
- [ ] In phone landscape, switch serve between teams — volleyball icon reaches the right edge symmetrically
- [ ] In phone portrait, same serve-indicator check
- [ ] Clear localStorage, reload — no crash, no stale data