### PR TITLE
v3.04: FIVB side-switch at 8 pts, timer shake/vibration, background-tab fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Four views are shown/hidden by toggling the `hidden` class on their container di
 3. `#scoreboard` — active game screen
 4. `#matchResult` — post-match result
 
-Four modals are used across screens: `#subModal` (player substitution, overlays scoreboard), `#timeoutModal` (30-second countdown, overlays scoreboard), `#setBreakModal` (3-minute set break timer, shown between sets), and `#returnToSetupModal` (confirmation dialog for returning to setup mid-match).
+Five modals are used across screens: `#subModal` (player substitution, overlays scoreboard), `#timeoutModal` (30-second countdown, overlays scoreboard), `#setBreakModal` (3-minute set break timer, shown between sets), `#returnToSetupModal` (confirmation dialog for returning to setup mid-match), and `#deciderSwitchModal` (side-switch notification at 8 points in the deciding set).
 
 ### State management
 
@@ -78,6 +78,30 @@ When a set ends, `checkSetWin()` calls `showSetBreakModal(nextSetNumber)` which 
 
 `sw.js` — service worker. Cache name is `vbref-v${VERSION}`; **bump `VERSION` in `sw.js` to invalidate all clients on the next deploy** and force re-download of updated assets. `APP_SHELL` lists every file precached at install — **add new CSS, JS, or icon files here or they will not be available offline**. HTML navigations use network-first (fresh on online reload, cached fallback offline). All other same-origin assets use cache-first. Cross-origin requests (Google Fonts, Analytics) are not intercepted and not cached — they silently fail offline, which is acceptable.
 
+### Deciding-set side switch
+
+`state.deciderSideSwitched` (boolean, persisted) tracks whether the mid-set side switch has fired in the current deciding set. When either team reaches 8 points in a 15-point final set, `maybeTriggerDeciderSwitch()` fires `showDeciderSwitchModal()`. On confirm, `closeDeciderSwitchModal()` sets the flag to `true` then calls `swapTeams()`. The flag is reset in `resetMatchState()` and in the set-transition branch of `checkSetWin()`. It is intentionally **not** included in `pointHistory` snapshots — it is sticky for the set, so undoing the trigger point reverts the score but keeps the swap in place (same semantics as the manual swap button).
+
 ### Match state persistence
 
 The full `state` object is serialized to localStorage under the key `vb-match-state` after every `updateDisplay()` call. On `init()`, `restoreSavedMatch()` reads it and routes the user back to the correct screen (scoreboard / rotation setup / match result). Stored under a `_schema` version field — bump `STORAGE_SCHEMA` when the state shape changes in a way that breaks restore, and stale data is silently dropped. `resetMatchState()` clears the stored state so a "Return to Setup" reliably starts fresh. Timer intervals (timeout countdown, set break) live in module-level vars, not in state — they are NOT restored, so a timeout interrupted by reload simply ends.
+
+## Code Review Checklist
+
+Every code review for this repo **must** verify UI across all of these viewports:
+
+| Viewport | Dimensions |
+|---|---|
+| Desktop | 1280 × 800 (or wider) |
+| Tablet landscape | 1024 × 768 |
+| Tablet portrait | 768 × 1024 |
+| Mobile portrait | 390 × 844 (iPhone 14 proxy) |
+| Mobile landscape | 844 × 390 |
+| Small phone | 375 × 667 (iPhone SE proxy) |
+
+For each affected screen/modal, confirm:
+- No overflow or horizontal scroll
+- Touch targets are large enough (≥ 44px)
+- Text is readable (no truncation, no overlap)
+- Modals are fully visible and scrollable if needed
+- Buttons and interactive elements are reachable (not clipped by safe-area or other elements)

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The app is fully responsive and optimized for:
 
 ## Version History
 
+- **v3.04** - FIVB Rule 18.2.2: automatic side-switch modal when either team reaches 8 points in the deciding set; survives page reload. Also adds timer-end shake animations and haptic feedback (vibration on supporting devices) for timer expirations and the deciding-set side-switch popup. Timeout and set-break timers now keep accurate time when the browser tab is in the background.
 - **v3.03** - Schema migration framework for future localStorage upgrades; rotation-setup state persisted across reloads; match history log with per-set score pills
 - **v3.02** - Match state survives app close/reload (full scoresheet retention via localStorage)
 - **v3.01** - PWA support: installable to home screen, full offline capability via service worker

--- a/app.js
+++ b/app.js
@@ -33,7 +33,8 @@ const state = {
     team2OriginalId: 'B',
     lastStartingRotation1: null,
     lastStartingRotation2: null,
-    matchStarted: false
+    matchStarted: false,
+    deciderSideSwitched: false
 };
 
 const rotationSetupState = {
@@ -54,6 +55,8 @@ const TIMER_CIRCLE_CIRCUMFERENCE = 2 * Math.PI * TIMER_CIRCLE_RADIUS;
 
 let timeoutInterval = null;
 let setBreakInterval = null;
+let vibrateInterval = null;
+let _alertContentEl = null;
 let _scorePulseTeam = null;
 let _dndInitialized = false;
 let _restoredRotationSetup = null;
@@ -296,6 +299,8 @@ function restoreSavedMatch() {
     // matchStarted covers no-jersey matches; team1Players.length covers old saves from jersey matches
     const inProgress = state.matchStarted || state.team1Players.length > 0;
 
+    let onScoreboard = false;
+
     if (state.matchOver) {
         endMatch();
     } else if (!inProgress) {
@@ -313,6 +318,7 @@ function restoreSavedMatch() {
         document.getElementById('rotation1').classList.remove('hidden');
         document.getElementById('rotation2').classList.remove('hidden');
         updateDisplay();
+        onScoreboard = true;
     } else if (state.hasRotation) {
         _restoredRotationSetup = savedRS || null;
         showNewSetRotationSetup();
@@ -324,7 +330,15 @@ function restoreSavedMatch() {
         document.getElementById('rotation1').classList.add('hidden');
         document.getElementById('rotation2').classList.add('hidden');
         updateDisplay();
+        onScoreboard = true;
     }
+
+    if (onScoreboard && !state.matchOver && !state.deciderSideSwitched
+            && getPointsToWin() === FINAL_SET_POINTS
+            && (state.team1Score >= 8 || state.team2Score >= 8)) {
+        showDeciderSwitchModal();
+    }
+
     return true;
 }
 
@@ -386,6 +400,7 @@ function init() {
     document.getElementById('returnToSetup').addEventListener('click', showReturnToSetupModal);
     document.getElementById('cancelReturnToSetup').addEventListener('click', closeReturnToSetupModal);
     document.getElementById('confirmReturnToSetup').addEventListener('click', confirmReturnToSetup);
+    document.getElementById('confirmDeciderSwitch').addEventListener('click', closeDeciderSwitchModal);
 
     document.querySelectorAll('.rotation-setup-pos').forEach(pos => {
         pos.addEventListener('click', handlePositionClick);
@@ -473,13 +488,13 @@ function showTimeoutModal(teamName) {
     modal.classList.remove('hidden');
 
     const timeoutDurationMs = TIMEOUT_DURATION * 1000;
-    let timeLeft = timeoutDurationMs;
+    const startTime = performance.now();
     timerProgress.style.strokeDashoffset = 0;
 
     const updateInterval = 10;
 
     timeoutInterval = setInterval(() => {
-        timeLeft -= updateInterval;
+        const timeLeft = Math.max(0, timeoutDurationMs - (performance.now() - startTime));
 
         const seconds = Math.floor(timeLeft / 1000);
         const milliseconds = Math.floor((timeLeft % 1000) / 10);
@@ -490,12 +505,15 @@ function showTimeoutModal(teamName) {
 
         if (timeLeft <= 0) {
             timerText.textContent = '0.00';
-            closeTimeoutModal();
+            clearInterval(timeoutInterval);
+            timeoutInterval = null;
+            shakeModal(modal.querySelector('.modal-content'));
         }
     }, updateInterval);
 }
 
 function closeTimeoutModal() {
+    stopRepeatingVibration();
     const modal = document.getElementById('timeoutModal');
     modal.classList.add('hidden');
 
@@ -518,13 +536,13 @@ function showSetBreakModal(setNumber) {
     modal.classList.remove('hidden');
 
     const setBreakDurationMs = SET_BREAK_DURATION * 1000;
-    let timeLeft = setBreakDurationMs;
+    const startTime = performance.now();
     timerProgress.style.strokeDashoffset = 0;
 
     const updateInterval = 100; // Update every 100ms for second-level precision
 
     setBreakInterval = setInterval(() => {
-        timeLeft -= updateInterval;
+        const timeLeft = Math.max(0, setBreakDurationMs - (performance.now() - startTime));
 
         // Format as mm:ss
         const totalSeconds = Math.floor(timeLeft / 1000);
@@ -537,12 +555,15 @@ function showSetBreakModal(setNumber) {
 
         if (timeLeft <= 0) {
             timerText.textContent = '0:00';
-            closeSetBreakModal();
+            clearInterval(setBreakInterval);
+            setBreakInterval = null;
+            shakeModal(modal.querySelector('.modal-content'));
         }
     }, updateInterval);
 }
 
 function closeSetBreakModal() {
+    stopRepeatingVibration();
     const modal = document.getElementById('setBreakModal');
     modal.classList.add('hidden');
 
@@ -738,10 +759,12 @@ function closeReturnToSetupModal() {
 }
 
 function confirmReturnToSetup() {
+    stopRepeatingVibration();
     closeReturnToSetupModal();
     closeTimeoutModal();
     if (setBreakInterval) { clearInterval(setBreakInterval); setBreakInterval = null; }
     document.getElementById('setBreakModal').classList.add('hidden');
+    document.getElementById('deciderSwitchModal').classList.add('hidden');
     closeSubModal();
     resetToSetup();
 }
@@ -917,6 +940,37 @@ function swapTeams() {
     updateDisplay();
 }
 
+function maybeTriggerDeciderSwitch() {
+    if (state.deciderSideSwitched) return;
+    if (state.matchOver) return;
+    if (getPointsToWin() !== FINAL_SET_POINTS) return;
+    if (state.team1Score < 8 && state.team2Score < 8) return;
+    showDeciderSwitchModal();
+}
+
+function showDeciderSwitchModal() {
+    const scoreEl = document.getElementById('deciderSwitchScore');
+    const cs = getComputedStyle(document.documentElement);
+    const colorA = cs.getPropertyValue('--team1-color').trim();
+    const colorB = cs.getPropertyValue('--team2-color').trim();
+    const t1Color = state.team1OriginalId === 'A' ? colorA : colorB;
+    const t2Color = state.team2OriginalId === 'A' ? colorA : colorB;
+    scoreEl.innerHTML =
+        `<span style="color:${t1Color}">${escapeHtml(state.team1Name)} ${state.team1Score}</span>` +
+        ` <span class="decider-switch-sep">·</span> ` +
+        `<span style="color:${t2Color}">${escapeHtml(state.team2Name)} ${state.team2Score}</span>`;
+    vibrateDevice([300, 100, 300, 100, 500]);
+    document.getElementById('deciderSwitchModal').classList.remove('hidden');
+}
+
+function closeDeciderSwitchModal() {
+    const modal = document.getElementById('deciderSwitchModal');
+    if (modal.classList.contains('hidden')) return;
+    state.deciderSideSwitched = true;
+    modal.classList.add('hidden');
+    swapTeams();
+}
+
 function startMatch() {
     const team1Name = document.getElementById('team1Name').value || 'Team A';
     const team2Name = document.getElementById('team2Name').value || 'Team B';
@@ -1033,6 +1087,39 @@ function isValidJersey(value) {
 
 function escapeHtml(str) {
     return String(str).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+function vibrateDevice(pattern) {
+    try {
+        if (navigator.vibrate) navigator.vibrate(pattern);
+    } catch (_) {}
+}
+
+function stopRepeatingVibration() {
+    if (vibrateInterval) {
+        clearInterval(vibrateInterval);
+        vibrateInterval = null;
+    }
+    try { if (navigator.vibrate) navigator.vibrate(0); } catch (_) {}
+    if (_alertContentEl) {
+        _alertContentEl.classList.remove('modal-shake');
+        _alertContentEl = null;
+    }
+}
+
+function shakeModal(contentEl) {
+    stopRepeatingVibration();
+    _alertContentEl = contentEl;
+
+    function pulse() {
+        try { if (navigator.vibrate) navigator.vibrate([200, 100, 200]); } catch (_) {}
+        contentEl.classList.remove('modal-shake');
+        void contentEl.offsetWidth;
+        contentEl.classList.add('modal-shake');
+    }
+
+    pulse();
+    vibrateInterval = setInterval(pulse, 1500);
 }
 
 
@@ -1325,6 +1412,7 @@ function resetMatchState() {
     state.lastStartingRotation1 = null;
     state.lastStartingRotation2 = null;
     state.matchStarted = false;
+    state.deciderSideSwitched = false;
     _restoredRotationSetup = null;
 }
 
@@ -1389,6 +1477,7 @@ function addPoint(team) {
 
     checkSetWin();
     updateDisplay();
+    maybeTriggerDeciderSwitch();
 }
 
 function checkSetWin() {
@@ -1456,6 +1545,7 @@ function checkSetWin() {
             state.currentSetPoints = [];
             state.serving = (state.currentSet % 2 === 1) ? 1 : 2;
             state.firstServer = state.serving;
+            state.deciderSideSwitched = false;
 
             switchSides();
 

--- a/index.html
+++ b/index.html
@@ -301,6 +301,17 @@
         </div>
     </div>
 
+    <div id="deciderSwitchModal" class="modal hidden">
+        <div class="modal-content decider-switch-content">
+            <div class="decider-switch-icon">⇄</div>
+            <h2>Switch Sides</h2>
+            <p class="decider-switch-subtitle">A team has reached 8 points in the deciding set.</p>
+            <p class="decider-switch-rule">FIVB Rule: teams change courts at 8 points in the final set.</p>
+            <div class="decider-switch-score" id="deciderSwitchScore"></div>
+            <button class="btn btn-primary" id="confirmDeciderSwitch">Switch Sides</button>
+        </div>
+    </div>
+
     <div id="returnToSetupModal" class="modal hidden">
         <div class="modal-content">
             <div class="confirm-icon">↩️</div>
@@ -322,7 +333,7 @@
         </div>
     </div>
 
-    <footer class="credits">v3.03 | Created by Menon Pranto</footer>
+    <footer class="credits">v3.04 | Created by Menon Pranto</footer>
 
     <script src="app.js"></script>
     <script>

--- a/styles.css
+++ b/styles.css
@@ -2257,6 +2257,44 @@ h1 {
     box-shadow: 0 0 12px rgba(245, 200, 66, 0.4) !important;
 }
 
+/* ── Decider Side-Switch Modal ───────────────────────────────────────────── */
+.decider-switch-content {
+    text-align: center;
+}
+
+.decider-switch-icon {
+    font-size: 3rem;
+    margin-bottom: 0.5rem;
+    line-height: 1;
+    opacity: 0.9;
+    color: var(--court-gold);
+}
+
+.decider-switch-subtitle {
+    color: var(--court-cream-dim);
+    font-size: 0.95rem;
+    margin: 0.25rem 0 0.15rem;
+}
+
+.decider-switch-rule {
+    color: var(--court-cream-off);
+    font-size: 0.78rem;
+    font-style: italic;
+    margin: 0 0 1rem;
+}
+
+.decider-switch-score {
+    font-size: 1.35rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    margin-bottom: 1.25rem;
+}
+
+.decider-switch-sep {
+    color: rgba(255,255,255,0.4);
+    margin: 0 0.4em;
+}
+
 /* ── Animations ──────────────────────────────────────────────────────────── */
 
 @keyframes scorePulse {
@@ -2269,6 +2307,27 @@ h1 {
 @keyframes modalIn {
     from { opacity: 0; transform: scale(0.94) translateY(8px); }
     to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+@keyframes modalShake {
+    0%, 100% { transform: translateX(0) rotate(0); }
+    10% { transform: translateX(-10px) rotate(-1deg); }
+    20% { transform: translateX(10px) rotate(1deg); }
+    30% { transform: translateX(-8px) rotate(-0.8deg); }
+    40% { transform: translateX(8px) rotate(0.8deg); }
+    50% { transform: translateX(-6px) rotate(-0.6deg); }
+    60% { transform: translateX(6px) rotate(0.6deg); }
+    70% { transform: translateX(-4px); }
+    80% { transform: translateX(4px); }
+    90% { transform: translateX(-2px); }
+}
+
+.modal-content.modal-shake {
+    animation: modalShake 0.7s cubic-bezier(0.36, 0.07, 0.19, 0.97);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .modal-content.modal-shake { animation: none; }
 }
 
 /* ── History Button ──────────────────────────────────────────────────────── */

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const VERSION = 'v3.0.3';
+const VERSION = 'v3.0.4';
 const CACHE = `vbref-${VERSION}`;
 // Add every new app-shell asset here or it will not be available offline.
 const APP_SHELL = [


### PR DESCRIPTION
## Summary

- **FIVB Rule 18.2.2 — automatic side switch at 8 points in the deciding set.** When either team reaches 8 in a 15-point final set, a modal blocks play and prompts the referee to switch sides. Confirming calls `swapTeams()`. A sticky `deciderSideSwitched` flag ensures the trigger fires exactly once per set, persists across reloads, and handles undo correctly (score reverts, sides stay swapped — matches existing manual-swap behaviour).
- **Timer expiry alert: repeating shake + vibration.** When the 30-second timeout or 3-minute set-break countdown hits zero, the modal shakes and the device vibrates on a 1.5-second loop until the referee presses Continue. Uses `performance.now()`-based timing so the shake/vibrate loop isn't throttled in background tabs.
- **Background-tab timer accuracy fix.** Both timers previously decremented a counter per tick, causing them to pause when the tab was hidden. Replaced with wall-clock elapsed-time computation (`performance.now()`); timers now catch up instantly on tab refocus.
- **Deciding-set side-switch popup triggers a one-shot haptic** (`[300, 100, 300, 100, 500]` pattern) when shown.
- **`prefers-reduced-motion` respected** for the shake animation (animation disabled; vibration unaffected).

## Test plan

- [ ] Start a best-of-3 match, win one set each → force set 3 (15 pts). Score to 8 for either team — confirm the side-switch modal appears with correct team scores in team colours
- [ ] Press "Switch Sides" — confirm names, scores, rotations, and serve indicator all swap correctly; modal closes
- [ ] Score more points — confirm the modal does NOT reappear (one-time trigger)
- [ ] Reload mid-set with score ≥ 8 before confirming — confirm modal re-shows
- [ ] Undo the 8th point — confirm score reverts to 7, sides remain swapped, re-scoring 8 is silent
- [ ] Start a timeout — let it count to zero. Confirm the modal shakes and vibrates on a repeating ~1.5s cycle
- [ ] Press "Continue Early" mid-shake — confirm vibration stops immediately and modal closes cleanly
- [ ] Let the set-break timer expire — confirm same shake/vibrate loop behaviour
- [ ] Switch to another tab mid-countdown, return after the timer has expired — confirm the modal fires the expiry alert immediately on return (background-tab fix)
- [ ] Switch tabs during an active countdown and return before expiry — confirm the displayed time reflects real elapsed time (no freeze)
- [ ] Return to Setup while a timer is ringing — confirm vibration stops and all modals close cleanly