### PR TITLE
Add security policy, issue templates, and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Something isn't working correctly
+title: ''
+labels: bug
+assignees: ''
+---
+
+## What happened?
+
+<!-- Describe the bug clearly. What did you do, what did you expect, what actually occurred? -->
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behavior
+
+<!-- What should have happened? -->
+
+## Environment
+
+- **App version:** (shown in the footer at the bottom of the app)
+- **Browser + version:** (e.g. Safari 17.4, Chrome 124)
+- **Device + OS:** (e.g. iPhone 15 / iOS 17.4, Samsung Galaxy S24 / Android 14, MacBook)
+- **Screen orientation:** (portrait / landscape / desktop)
+
+## Have you tried a hard reload?
+
+Because the app can be installed as a PWA, an outdated cached version sometimes causes stale-state bugs. Before filing, please try a hard reload (Cmd+Shift+R / Ctrl+Shift+R) or uninstalling and reinstalling the PWA.
+
+- [ ] Yes, I've tried a hard reload and the bug persists
+
+## Screenshots or recording
+
+<!-- If applicable, drag and drop an image or screen recording here. -->
+
+## Additional context
+
+<!-- Anything else that might help: was the app installed as a PWA, was the tab in the background, did it happen after a page reload, etc.? -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+> **Tip:** For open-ended proposals or "what if" ideas, consider starting a thread in [Discussions](https://github.com/watermenon09/VolleyballReferee/discussions) first. Use this template once the idea is concrete.
+
+## What problem does this solve?
+
+<!-- Describe the situation or gap this addresses. e.g. "During a deciding set, I need to track X because..." -->
+
+## Proposed solution
+
+<!-- Describe what you'd like to see. Be as specific as you can — what would the UI look like, what would the user do? -->
+
+## Alternatives considered
+
+<!-- Any other approaches you've thought about? Why do you prefer the proposed solution? -->
+
+## Volleyball rule reference (if applicable)
+
+<!-- If this relates to a specific FIVB rule, paste the rule number and text here. -->
+
+## Additional context
+
+<!-- Screenshots, mockups, links, or anything else that helps explain the idea. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+## Summary
+
+<!-- What does this PR do and why? One or two sentences. -->
+
+Closes #<!-- issue number, if applicable -->
+
+## Changes
+
+<!-- Bullet list of what changed. Keep it factual — the diff already shows what, focus on why. -->
+
+-
+
+## Testing
+
+**Browsers tested:**
+- [ ] Chrome
+- [ ] Safari
+
+**Viewports tested** (check all that apply to your change):
+
+| Viewport | Tested |
+|---|---|
+| Desktop (1280×800) | |
+| Tablet landscape (1024×768) | |
+| Tablet portrait (768×1024) | |
+| Mobile portrait (390×844) | |
+| Mobile landscape (844×390) | |
+| Small phone (375×667) | |
+
+## Screenshots / recording
+
+<!-- For any UI change, include a screenshot or short GIF. Drag and drop here. -->
+
+## Checklist
+
+- [ ] All `state` mutations end with `updateDisplay()`
+- [ ] No new files created unless genuinely required
+- [ ] No external dependencies added
+- [ ] If assets were added/removed/renamed: `VERSION` bumped and `APP_SHELL` updated in `sw.js`
+- [ ] If the `state` object shape changed in a breaking way: `STORAGE_SCHEMA` bumped in `app.js`
+- [ ] If a new mutable `state` field was added: included in the `pointHistory` snapshot so undo restores it
+- [ ] README "Version History" entry added and `index.html` footer version updated
+- [ ] UI verified at the viewports above

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported versions
+
+Volleyball Referee is a client-side web app with no server component, no user accounts, and no first-party data collection. All match state is stored locally in the browser (`localStorage`). The page does load Google Fonts and Google Analytics from third parties — beyond that, there is no backend to compromise.
+
+That said, vulnerabilities affecting users — such as cross-site scripting (XSS) in markup or script injection through user inputs — are still taken seriously.
+
+The current release on the `main` branch is the only supported version.
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report privately via [GitHub's private vulnerability reporting](https://github.com/watermenon09/VolleyballReferee/security/advisories/new), or email **ahnaftanjid@cloudly.io** with:
+
+- A description of the vulnerability
+- Steps to reproduce or a proof-of-concept
+- The potential impact
+- Suggested fix (optional)
+
+You'll receive an acknowledgement within 72 hours. If the vulnerability is confirmed, a fix will be prioritized and a patched release published. You'll be credited in the release notes unless you prefer otherwise.
+
+## Scope
+
+| In scope | Out of scope |
+|---|---|
+| XSS via user-controlled inputs (jersey numbers, team names) | Theoretical issues with no realistic exploit path |
+| Script injection through `localStorage` state restore | Social engineering |
+| Unintended data exposure via the PWA / service worker cache | Issues in third-party tools or browser extensions |
+
+## Disclosure policy
+
+Once a fix is deployed to `main` (and live at the GitHub Pages URL), the vulnerability may be disclosed publicly. Coordinated disclosure is appreciated — please allow reasonable time for a fix before publishing details.


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md` with private disclosure instructions, scope table, and 72-hour SLA
- Adds `.github/ISSUE_TEMPLATE/bug_report.md` with structured fields for browser/device/version and a PWA hard-reload check
- Adds `.github/ISSUE_TEMPLATE/feature_request.md` with a Discussions-first hint and FIVB rule reference field
- Adds `.github/pull_request_template.md` with viewport checklist, and gates for `updateDisplay()`, `sw.js` VERSION/APP_SHELL, `STORAGE_SCHEMA`, `pointHistory` snapshot, and version bump

## Test plan

- [ ] Visit the repo's Issues tab — template picker should show Bug report and Feature request
- [ ] Open a new PR — the PR template should auto-populate
- [ ] Check Security tab — SECURITY.md should surface as the security policy